### PR TITLE
Use DeepCopy instead of passing by reference

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	mesheryv1alpha1 "github.com/layer5io/meshery-operator/api/v1alpha1"
 	mesherykube "github.com/layer5io/meshkit/utils/kubernetes"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +36,8 @@ func GetObjects(m *mesheryv1alpha1.Broker) map[string]Object {
 }
 
 func getServerObject(namespace, name string, replicas int32) Object {
-	obj := StatefulSet
+	var obj = &v1.StatefulSet{}
+	StatefulSet.DeepCopyInto(obj)
 	obj.ObjectMeta.Namespace = namespace
 	obj.ObjectMeta.Name = name
 	obj.Spec.Replicas = &replicas
@@ -43,19 +45,22 @@ func getServerObject(namespace, name string, replicas int32) Object {
 }
 
 func getServiceObject(namespace, name string) Object {
-	obj := Service
+	var obj = &corev1.Service{}
+	Service.DeepCopyInto(obj)
 	obj.ObjectMeta.Name = name
 	obj.ObjectMeta.Namespace = namespace
 	return obj
 }
 
 func getServerConfig() Object {
-	obj := NatsConfigMap
+	var obj = &corev1.ConfigMap{}
+	NatsConfigMap.DeepCopyInto(obj)
 	return obj
 }
 
 func getAccountConfig() Object {
-	obj := AccountsConfigMap
+	var obj = &corev1.ConfigMap{}
+	AccountsConfigMap.DeepCopyInto(obj)
 	return obj
 }
 

--- a/pkg/meshsync/meshsync.go
+++ b/pkg/meshsync/meshsync.go
@@ -2,6 +2,7 @@ package meshsync
 
 import (
 	mesheryv1alpha1 "github.com/layer5io/meshery-operator/api/v1alpha1"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -22,7 +23,8 @@ func GetObjects(m *mesheryv1alpha1.MeshSync) map[string]Object {
 }
 
 func getServerObject(namespace, name string, replicas int32, url string) Object {
-	obj := Deployment
+	var obj = &v1.Deployment{}
+	Deployment.DeepCopyInto(obj)
 	obj.ObjectMeta.Namespace = namespace
 	obj.ObjectMeta.Name = name
 	obj.Spec.Replicas = &replicas


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

This PR fixes #
Recently we were facing panic on operator due the fact that it tried to assert an array's index from a struct which was being manipulated because of being passed around by reference. This PR adds a DeepCopy  method to copy the original struct without changing it to avoid panic in future. 
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
