### PR TITLE
feat: Add test for meshsync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,8 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 # Test coverage
-.PHONY: coverage
-coverage: ## Generate test coverage report
+.PHONY: coverage 
+coverage: test-env
 	go test -v ./... -coverprofile cover.out
 	go tool cover -html=cover.out -o cover.html
 
@@ -295,4 +295,4 @@ $(BIN_DIR)/setup-envtest-$(SETUP_ENVTEST_VERSION):
 .PHONY: test-env
 test-env:
 	make bin/setup-envtest
-	bin//setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR)
+	bin/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR)

--- a/pkg/meshsync/meshsync_test.go
+++ b/pkg/meshsync/meshsync_test.go
@@ -17,33 +17,27 @@ limitations under the License.
 package meshsync
 
 import (
+	"testing"
+
 	mesheryv1alpha1 "github.com/layer5io/meshery-operator/api/v1alpha1"
-	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	ServerObject = "server-object"
-)
-
-type Object interface {
-	runtime.Object
-	metav1.Object
-}
-
-func GetObjects(m *mesheryv1alpha1.MeshSync) map[string]Object {
-	return map[string]Object{
-		ServerObject: getServerObject(m.ObjectMeta.Namespace, m.ObjectMeta.Name, m.Spec.Size, m.Status.PublishingTo),
+func TestGetObjects(t *testing.T) {
+	m := &mesheryv1alpha1.MeshSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: mesheryv1alpha1.MeshSyncSpec{
+			Size: 1,
+		},
 	}
-}
-
-func getServerObject(namespace, name string, replicas int32, url string) Object {
-	var obj = &v1.Deployment{}
-	Deployment.DeepCopyInto(obj)
-	obj.ObjectMeta.Namespace = namespace
-	obj.ObjectMeta.Name = name
-	obj.Spec.Replicas = &replicas
-	obj.Spec.Template.Spec.Containers[0].Env[0].Value = url // Set broker endpoint
-	return obj
+	obj := GetObjects(m)
+	if obj == nil {
+		t.Error("GetObjects returned nil")
+	}
+	if obj[ServerObject] == nil {
+		t.Error("GetObjects returned nil for server object")
+	}
 }

--- a/pkg/meshsync/resources.go
+++ b/pkg/meshsync/resources.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Layer5, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package meshsync
 
 import (


### PR DESCRIPTION
**Description**

This PR is related to #463 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

```
@Aisuko ➜ /workspaces/meshery-operator (feat/meshsync) $ make coverage
make bin/setup-envtest
make[1]: Entering directory '/workspaces/meshery-operator'
go: downloading sigs.k8s.io/controller-runtime v0.13.1-0.20221212190805-d4f1e822ca11
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20221212190805-d4f1e822ca11
go: downloading github.com/go-logr/zapr v1.2.0
go: downloading github.com/go-logr/logr v1.2.0
go: downloading github.com/spf13/afero v1.6.0
go: downloading go.uber.org/zap v1.19.1
go: downloading golang.org/x/text v0.3.7
go: downloading go.uber.org/atomic v1.7.0
make[1]: Leaving directory '/workspaces/meshery-operator'
bin/setup-envtest use 1.24.2 --bin-dir /workspaces/meshery-operator/bin
Version: 1.24.2
OS/Arch: linux/amd64
md5: ZViX8vb02m8ULK0fkiNNGw==
Path: /workspaces/meshery-operator/bin/k8s/1.24.2-linux-amd64
go test -v ./... -coverprofile cover.out
?       github.com/layer5io/meshery-operator    [no test files]
=== RUN   TestAPIs
Running Suite: APIs Suite - /workspaces/meshery-operator/api/v1alpha1
=====================================================================
Random Seed: 1684734948

Will run 12 of 12 specs
••••••••••••

Ran 12 of 12 Specs in 0.005 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (0.01s)
PASS
        github.com/layer5io/meshery-operator/api/v1alpha1       coverage: 49.2% of statements
ok      github.com/layer5io/meshery-operator/api/v1alpha1       0.020s  coverage: 49.2% of statements
?       github.com/layer5io/meshery-operator/pkg/client [no test files]
?       github.com/layer5io/meshery-operator/pkg/client/v1alpha1        [no test files]
=== RUN   TestAPIs
Running Suite: Controller Suite - /workspaces/meshery-operator/controllers
==========================================================================
Random Seed: 1684734951

Will run 11 of 11 specs
Ran 11 of 11 Specs in 66.117 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (66.12s)
PASS
        github.com/layer5io/meshery-operator/controllers        coverage: 48.8% of statements
ok      github.com/layer5io/meshery-operator/controllers        66.152s coverage: 48.8% of statements
=== RUN   TestAPIs
Running Suite: Broker Suite - /workspaces/meshery-operator/pkg/broker
=====================================================================
Random Seed: 1684734951

Will run 3 of 3 specs
•••

Ran 3 of 3 Specs in 5.486 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (5.49s)
PASS
        github.com/layer5io/meshery-operator/pkg/broker coverage: 73.7% of statements
ok      github.com/layer5io/meshery-operator/pkg/broker 5.519s  coverage: 73.7% of statements
=== RUN   TestGetObjects
--- PASS: TestGetObjects (0.00s)
PASS
        github.com/layer5io/meshery-operator/pkg/meshsync       coverage: 100.0% of statements
ok      github.com/layer5io/meshery-operator/pkg/meshsync       0.007s  coverage: 100.0% of statements
go tool cover -html=cover.out -o cover.html
```
