### PR TITLE
Fixed build failed

### DIFF
--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -29,7 +29,7 @@ import (
 
 	mesheryv1alpha1 "github.com/layer5io/meshery-operator/api/v1alpha1"
 	brokerpackage "github.com/layer5io/meshery-operator/pkg/broker"
-	"github.com/meshery/meshery-operator/pkg/utils"
+	"github.com/layer5io/meshery-operator/pkg/utils"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 	types "k8s.io/apimachinery/pkg/types"
 )

--- a/controllers/meshsync_controller.go
+++ b/controllers/meshsync_controller.go
@@ -31,7 +31,7 @@ import (
 	mesheryv1alpha1 "github.com/layer5io/meshery-operator/api/v1alpha1"
 	brokerpackage "github.com/layer5io/meshery-operator/pkg/broker"
 	meshsyncpackage "github.com/layer5io/meshery-operator/pkg/meshsync"
-	"github.com/meshery/meshery-operator/pkg/utils"
+	"github.com/layer5io/meshery-operator/pkg/utils"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 	types "k8s.io/apimachinery/pkg/types"
 )

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/layer5io/meshery-operator
 
 go 1.21
 
-toolchain go1.21.2
-
 replace (
-	github.com/meshery/meshery-operator => ../meshery-operator
 	k8s.io/api => k8s.io/api v0.25.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.25.3
 	k8s.io/apimachinery => k8s.io/apimachinery v0.25.3
@@ -16,7 +13,6 @@ replace (
 
 require (
 	github.com/go-logr/logr v1.2.4
-	github.com/meshery/meshery-operator v0.0.0-00010101000000-000000000000
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
 	k8s.io/api v0.26.1
@@ -60,6 +56,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -7,7 +7,7 @@ import (
 	neturl "net/url"
 
 	mesheryv1alpha1 "github.com/layer5io/meshery-operator/api/v1alpha1"
-	utils "github.com/meshery/meshery-operator/pkg/utils"
+	utils "github.com/layer5io/meshery-operator/pkg/utils"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**Description**

This PR fixes #530 

**Notes for Reviewers**

Here we remove the replace model. We need to replace the path of the specific package because go does not support import new local packages. Now we have it on GitHub, we can remove it.

The build process failed here because we have a `toolchain go1.21.1` on go.mod. No sure why we have it. I am guessing it is generated by VSCode. So, we already removed it.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
