### PR TITLE
fix: meshsync: remove broker-irl from input params as it is taken from env variables in meshsync code

### DIFF
--- a/pkg/meshsync/resources.go
+++ b/pkg/meshsync/resources.go
@@ -80,7 +80,7 @@ var (
 						},
 					},
 					Command: []string{
-						"./meshery-meshsync", "--broker-url", "$(BROKER_URL)",
+						"./meshery-meshsync",
 					},
 					Env: []corev1.EnvVar{
 						{


### PR DESCRIPTION
**Description**

Meshsync is taken broker-url from env variable.

Meshery Opertor also set up the value of env variable. 

But except this it also tries to run meshsycnc as 
```sh
meshery-meshsync --broker-url $(BROKER_URL)
```

but meshsync does not process this input param, it takes broker url from env variable: [main.go#110](url)

Since release of https://github.com/meshery/meshsync/releases/tag/v0.8.7 we no have issue, as we used "flag" package which fails if provided flag is not defined. 

This fix removes (unused and undefined) param from meshsync binary call.  

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
