### PR TITLE
fix: replace empty mock with nil when perform TcpCheck to prevent TcpCheck always return false

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -148,7 +148,7 @@ func GetEndpoint(ctx context.Context, m *mesheryv1alpha1.Broker, client *kuberne
 		endpoint.Internal = &utils.HostPort{}
 	}
 	// If external endpoint not reachable
-	if !utils.TcpCheck(endpoint.External, &utils.MockOptions{}) && endpoint.External.Address != "localhost" {
+	if !utils.TcpCheck(endpoint.External, nil) && endpoint.External.Address != "localhost" {
 		newUrl, err = neturl.Parse(url)
 		if err != nil {
 			return nil
@@ -160,9 +160,9 @@ func GetEndpoint(ctx context.Context, m *mesheryv1alpha1.Broker, client *kuberne
 		// Set to APIServer host (For minikube specific clusters)
 		endpoint.External.Address = host
 		// If still unable to reach, change to resolve to clusterPort
-		if !utils.TcpCheck(endpoint.External, &utils.MockOptions{}) && endpoint.External.Address != "localhost" {
+		if !utils.TcpCheck(endpoint.External, nil) && endpoint.External.Address != "localhost" {
 			endpoint.External.Port = nodePort
-			if !utils.TcpCheck(endpoint.External, &utils.MockOptions{}) {
+			if !utils.TcpCheck(endpoint.External, nil) {
 				return ErrGettingEndpoint(fmt.Errorf("unable to connect to endpoint at %v", endpoint.External))
 			}
 		}


### PR DESCRIPTION
**Description**

This PR fixes error in connectivity checks. 

As you can see on [line 30](https://github.com/meshery/meshery-operator/blob/master/pkg/utils/Endpoint.go#L30) when mock is not nil, the result of tcp check is determine by desired endpoint == actual endpoint. 

As empty MockOptios is passing to TcpCheck it incorrectly always returns false.

TcpCheck checks are performed on External endpoint, and as it is always returns false, it results in the scenario when operator is not able to confirm that broker is deployed and not populating Endpoint in broker crd. 

This only the case when deployment is out of cluster (as checks are performed on External endpoint only) that is why in-cluster right now working fine. 

---
<details>
<summary>before fix: no endpoint object in broker crd</summary>
<img width="1259" height="411" alt="image" src="https://github.com/user-attachments/assets/44603410-af7f-459a-8adb-ae4d79695a87" />

</details>

<details>
<summary>after fix: endpoint object in broker crd is created successfully</summary>
<img width="1258" height="504" alt="image" src="https://github.com/user-attachments/assets/cc1ef72f-5206-4435-b578-922aaa5b5882" />

</details>


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
