### PR TITLE
[k8s] Create `meshSync` Kubernetes Health Probes

### DIFF
--- a/pkg/meshsync/resources.go
+++ b/pkg/meshsync/resources.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var (
@@ -103,6 +104,30 @@ var (
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    CPULimit,
 							corev1.ResourceMemory: MemoryLimit,
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						InitialDelaySeconds: 60,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      2,
+						FailureThreshold:    3,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz/livenessz",
+								Port: intstr.FromInt(11000),
+							},
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       4,
+						TimeoutSeconds:      2,
+						FailureThreshold:    3,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz/readinessz",
+								Port: intstr.FromInt(11000),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**Description**

This PR fixes #646

Create [Kubernetes Health Probles](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/) (Liveness probes on `/healthz/livenessz` and Readiness probes on `/healthz/readinessz` for `meshSync` containers and keep their lifecycle and state observed for reliability and stability.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
