### PR TITLE
Chore/workflow-permissions

### DIFF
--- a/.github/workflows/approve-to-run-ci.yml
+++ b/.github/workflows/approve-to-run-ci.yml
@@ -1,4 +1,5 @@
 name: Meshery-Operator CI
+permissions: read-all
 
 on:
   pull_request:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,4 +1,6 @@
 name: Meshery-Operator Build and Releaser
+permissions: read-all
+
 on:
   push:
     branches:

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -1,4 +1,6 @@
 name: Meshkit Error Codes Utility Runner
+permissions: read-all
+
 on:
     push:
         branches:
@@ -9,6 +11,9 @@ on:
 jobs:
     Update-error-codes:
         name: Error codes utility
+        permissions:
+          contents: write
+
         if: github.repository == 'meshery/meshery-operator'
         runs-on: ubuntu-24.04
         steps:

--- a/.github/workflows/integration-tests-ci.yml
+++ b/.github/workflows/integration-tests-ci.yml
@@ -1,4 +1,6 @@
 name: Integration Tests
+permissions: read-all
+
 on:
   push:
     branches:

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,4 +1,5 @@
 name: Label Commenter
+permissions: read-all
 
 on:
   issues:
@@ -9,13 +10,12 @@ on:
     types:
       - labeled
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-
 jobs:
   comment:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/newcomer-alert.yml
+++ b/.github/workflows/newcomer-alert.yml
@@ -1,4 +1,6 @@
 name: Newcomers Alert
+permissions: read-all
+
 on:
   issues:
     types: [labeled]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,5 @@
 name: Release Drafter
+permissions: read-all
 
 on:
   workflow_dispatch:
@@ -8,12 +9,11 @@ on:
     # paths-ignore:
     #   - '.github/**'
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   update_release_draft:
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.repository == 'meshery/meshery-operator'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -1,4 +1,5 @@
 name: Slack Notify
+permissions: read-all
 
 on:
   watch:


### PR DESCRIPTION
**Description**

This PR fixes #599

**Notes for Reviewers**
- Set all workflows to default to `permissions: read-all`
- Added job-level permission only for workflows that require write access with GITHUB_TOKEN

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
