### PR TITLE
fix: remove duplicate run key in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,8 +61,7 @@ formatters:
 
 run:
   timeout: 5m
-  enable-cache: true
-  skip-dirs:
+
 issues:
   exclude-dirs:
     - vendor
@@ -71,7 +70,3 @@ issues:
     - hack
     - helpers
     - img
-
-run:
-  timeout: 5m
-  enable-cache: true


### PR DESCRIPTION
**Description**

The golangci-lint CI step was failing due to a YAML parsing error.  
`Error: can't load config: can't read viper config: While parsing config: yaml: unmarshal errors:
  line 75: mapping key "run" already defined at line 62`
The `.golangci.yml`
 had a duplicate run key defined at both line 62 and line 75. This PR removes the duplicate section and cleans up the configuration.


This PR fixes #
https://github.com/meshery/meshery-operator/issues/694

**Notes for Reviewers**
- The duplicate run section (lines 75-77) has been removed
- The first run section has been cleaned up to only include timeout: 5m
- Verified locally that golangci-lint run executes successfully without YAML parsing errors

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
