### PR TITLE
Add MeshSync spec validation to reconciliation loop

### DIFF
--- a/controllers/error.go
+++ b/controllers/error.go
@@ -35,6 +35,7 @@ const (
 	ErrGetEndpointCode       = "1011"
 	ErrUpdateResourceCode    = "1012"
 	ErrMarshalCode           = "11049"
+	ErrValidateMeshsyncCode  = "1013"
 )
 
 // ErrGetMeshsync returns an error when unable to get meshsync resource
@@ -88,4 +89,8 @@ func ErrUpdateResource(err error) error {
 
 func ErrMarshal(err error) error {
 	return fmt.Errorf("%s: Error during marshaling: %w", ErrMarshalCode, err)
+}
+
+func ErrValidateMeshsync(err error) error {
+	return fmt.Errorf("%s: Invalid MeshSync spec: %w", ErrValidateMeshsyncCode, err)
 }

--- a/controllers/meshsync_controller.go
+++ b/controllers/meshsync_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -86,11 +87,55 @@ func (r *MeshSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// validateSpec validates the MeshSync spec before reconciliation
+func (r *MeshSyncReconciler) validateSpec(_ context.Context, log logr.Logger, baseResource *mesheryv1alpha1.MeshSync) error {
+	spec := baseResource.Spec
+	nullNative := mesheryv1alpha1.NativeMeshsyncBroker{}
+
+	hasNative := spec.Broker.Native != nullNative
+	hasCustom := spec.Broker.Custom.URL != ""
+
+	// 1. Broker: at least one must be configured
+	if !hasNative && !hasCustom {
+		return ErrValidateMeshsync(errors.New("broker must be configured: set either spec.broker.native or spec.broker.custom.url"))
+	}
+
+	// 2. Broker: both cannot be set at the same time
+	if hasNative && hasCustom {
+		return ErrValidateMeshsync(errors.New("spec.broker.native and spec.broker.custom.url are mutually exclusive, set only one"))
+	}
+
+	// 3. Native broker: Name and Namespace are both required
+	if hasNative {
+		if spec.Broker.Native.Name == "" {
+			return ErrValidateMeshsync(errors.New("spec.broker.native.name is required when using native broker"))
+		}
+		if spec.Broker.Native.Namespace == "" {
+			return ErrValidateMeshsync(errors.New("spec.broker.native.namespace is required when using native broker"))
+		}
+	}
+
+	// 4. Size: default to 1 if not set
+	if spec.Size == 0 {
+		log.Info("spec.size not set, defaulting to 1")
+		baseResource.Spec.Size = 1
+	}
+
+	return nil
+}
+
 // performReconciliation performs the main meshsync reconciliation logic
 func (r *MeshSyncReconciler) performReconciliation(ctx context.Context, log logr.Logger, baseResource *mesheryv1alpha1.MeshSync, req ctrl.Request) (ctrl.Result, error) {
 	// Set initial status to processing
 	if err := r.updateStatusCondition(ctx, baseResource, "Processing", v1.ConditionTrue, "Reconciling", "Reconciling meshsync"); err != nil {
 		log.Error(err, "Failed to update meshsync status to Processing")
+	}
+
+	// Validate spec before any side effects
+	if err := r.validateSpec(ctx, log, baseResource); err != nil {
+		log.Error(err, "MeshSync spec validation failed")
+		_ = r.updateStatusCondition(ctx, baseResource, "Failed", v1.ConditionFalse, "ValidationFailed", err.Error())
+		return ctrl.Result{}, err
 	}
 
 	// Get broker configuration

--- a/controllers/meshsync_controller.go
+++ b/controllers/meshsync_controller.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -27,6 +29,7 @@ import (
 	meshsyncpackage "github.com/meshery/meshery-operator/pkg/meshsync"
 	"github.com/meshery/meshery-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	kubeerror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,38 +90,97 @@ func (r *MeshSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// validateSpec validates the MeshSync spec before reconciliation
-func (r *MeshSyncReconciler) validateSpec(_ context.Context, log logr.Logger, baseResource *mesheryv1alpha1.MeshSync) error {
-	spec := baseResource.Spec
+func (r *MeshSyncReconciler) validateBrokerConfig(Broker mesheryv1alpha1.MeshsyncBroker) error {
 	nullNative := mesheryv1alpha1.NativeMeshsyncBroker{}
-
-	hasNative := spec.Broker.Native != nullNative
-	hasCustom := spec.Broker.Custom.URL != ""
+	hasNative := Broker.Native != nullNative
+	hasCustom := Broker.Custom.URL != ""
 
 	// 1. Broker: at least one must be configured
 	if !hasNative && !hasCustom {
-		return ErrValidateMeshsync(errors.New("broker must be configured: set either spec.broker.native or spec.broker.custom.url"))
+		return errors.New("broker must be configured: set either spec.broker.native or spec.broker.custom.url")
 	}
 
 	// 2. Broker: both cannot be set at the same time
 	if hasNative && hasCustom {
-		return ErrValidateMeshsync(errors.New("spec.broker.native and spec.broker.custom.url are mutually exclusive, set only one"))
+		return errors.New("spec.broker.native and spec.broker.custom.url are mutually exclusive, set only one")
 	}
 
 	// 3. Native broker: Name and Namespace are both required
 	if hasNative {
-		if spec.Broker.Native.Name == "" {
-			return ErrValidateMeshsync(errors.New("spec.broker.native.name is required when using native broker"))
+		if Broker.Native.Name == "" {
+			return errors.New("spec.broker.native.name is required when using native broker")
 		}
-		if spec.Broker.Native.Namespace == "" {
-			return ErrValidateMeshsync(errors.New("spec.broker.native.namespace is required when using native broker"))
+		if Broker.Native.Namespace == "" {
+			return errors.New("spec.broker.native.namespace is required when using native broker")
 		}
 	}
 
-	// 4. Size: default to 1 if not set
-	if spec.Size == 0 {
-		log.Info("spec.size not set, defaulting to 1")
-		baseResource.Spec.Size = 1
+	return nil
+}
+
+func (r *MeshSyncReconciler) validateWatchList(watchList corev1.ConfigMap) error {
+	// 1. If WatchList is provided, it must have a name
+	// (so the operator can actually find it in the cluster)
+	if watchList.Name == "" && watchList.Data != nil {
+		return errors.New("spec.watch-list must have a name when data is provided")
+	}
+
+	// 2. If name is provided, namespace should also be provided
+	if watchList.Name != "" && watchList.Namespace == "" {
+		return errors.New("spec.watch-list.namespace is required when name is set")
+	}
+
+	// 3. Validate the actual watch-list data keys are known/valid
+	validKeys := map[string]bool{
+		"blacklist": true,
+		"whitelist": true,
+	}
+	for key := range watchList.Data {
+		if !validKeys[key] {
+			return fmt.Errorf("spec.watch-list contains unknown key: %s", key)
+		}
+	}
+
+	return nil
+}
+
+func (r *MeshSyncReconciler) validateVersion(version string) error {
+	// 1. If provided, must follow semver format vX.Y.Z
+	if version == "" {
+		// empty is fine — operator can default to latest
+		return nil
+	}
+
+	// 2. Must match semantic versioning pattern
+	semverPattern := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	if !semverPattern.MatchString(version) {
+		return fmt.Errorf(
+			"spec.version '%s' is invalid, must follow semver format e.g. v0.1.0",
+			version,
+		)
+	}
+
+	return nil
+}
+
+// validateSpec validates the MeshSync spec before reconciliation
+func (r *MeshSyncReconciler) validateSpec(_ context.Context, baseResource *mesheryv1alpha1.MeshSync) error {
+	spec := baseResource.Spec
+	// 1. Validate broker configuration
+	if err := r.validateBrokerConfig(spec.Broker); err != nil {
+		return ErrValidateMeshsync(err)
+	}
+	// 2. Validate watch list configuration
+	if err := r.validateWatchList(spec.WatchList); err != nil {
+		return ErrValidateMeshsync(err)
+	}
+	// 3. Validate version format
+	if err := r.validateVersion(spec.Version); err != nil {
+		return ErrValidateMeshsync(err)
+	}
+	// 4. Size: must be between 1 and 10 if provided
+	if spec.Size < 1 || spec.Size > 10 {
+		return ErrValidateMeshsync(errors.New("spec.size must be between 1 and 10"))
 	}
 
 	return nil
@@ -132,8 +194,9 @@ func (r *MeshSyncReconciler) performReconciliation(ctx context.Context, log logr
 	}
 
 	// Validate spec before any side effects
-	if err := r.validateSpec(ctx, log, baseResource); err != nil {
-		log.Error(err, "MeshSync spec validation failed")
+	if err := r.validateSpec(ctx, baseResource); err != nil {
+		log.Error(err, "MeshSync resource configuration invalid",
+			"name", baseResource.Name)
 		_ = r.updateStatusCondition(ctx, baseResource, "Failed", v1.ConditionFalse, "ValidationFailed", err.Error())
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
**Description**

This PR fixes [#375](https://github.com/meshery/meshsync/issues/375)

**Notes for Reviewers**
This issue opened in MeshSync, but I see it needs to be implemented here for the following reasons
## Why this belongs in `meshery-operator`, not `meshsync`

The MeshSync CRD is defined and owned by `meshery-operator`. Its controller (`MeshSyncReconciler`) 
is the first process to handle a MeshSync resource — running before the MeshSync pod is ever scheduled. This means:

- Validation here prevents a bad spec from ever reaching deployment
- The controller can write a `ValidationFailed` status condition back to the CR, visible via `kubectl describe meshsync`
- The `meshsync` app only runs after the operator has already deployed it — by then it's too late to prevent a broken Deployment from being created

`meshsync` already has its own config validation in `crd_config.go` (`validateLists`), but that validates 
watch-list content at runtime, not the CR spec at admission time. These are complementary layers, not duplicates.

This issue tracks the operator-side gap. The `meshsync`-side validation (`crd_config.go`) is complete as-is.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
