### PR TITLE
feat: Add ARM multi-platform build support

### DIFF
--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -1,0 +1,115 @@
+name: Multi-Platform Build and Release
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*"
+    branches:
+      - "master"
+    paths-ignore:
+      - "docs/**"
+      - ".github/**"
+  workflow_dispatch:
+    inputs:
+      release-ver:
+        description: "Stable Release Version"
+        required: true
+        default: "v"
+      stripped-release-ver:
+        description: "Stripped Stable Release Version"
+        required: true
+        default: ""
+      release-channel:
+        description: "Release Channel"
+        required: true
+        default: "edge"
+
+env:
+  GIT_VERSION: ${{github.event.inputs.release-ver}}
+  GIT_STRIPPED_VERSION: ${{github.event.inputs.stripped-release-ver}}
+  RELEASE_CHANNEL: ${{github.event.inputs.release-channel}}
+  GIT_TAG: ${{ github.event.release.tag_name }}
+
+jobs:
+  print-inputs:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: |
+          echo "Dispatched GIT_VERSION: ${{github.event.inputs.release-ver}}"
+          echo "Dispatched GIT_STRIPPED_VERSION: ${{github.event.inputs.stripped-release-ver}}"
+          echo "Env RELEASE_CHANNEL: ${{env.RELEASE_CHANNEL}}"
+          echo "Env GIT_VERSION: ${{env.GIT_VERSION}}"
+          echo "Env GIT_STRIPPED_VERSION: ${{env.GIT_STRIPPED_VERSION}}"
+          echo "Env GIT_TAG: ${{ github.event.release.tag_name }}"
+          echo "Env GITHUB_REF: $GITHUB_REF"
+          echo "Env GITHUB_REF:" ${GITHUB_REF}
+
+  docker-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Identify Release Values
+        if: "${{ github.event.inputs.release-ver }} != 'v' }}"
+        run: |
+          if [[ ${GITHUB_REF} = refs/tags* ]]
+          then
+            echo RELEASE_CHANNEL=stable >> $GITHUB_ENV
+          else
+            echo RELEASE_CHANNEL=edge >> $GITHUB_ENV
+          fi
+          LATEST_VERSION=$(git ls-remote --sort='v:refname' --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g') >> $GITHUB_ENV
+          GIT_VERSION=$(git ls-remote --sort='v:refname' --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g') >> $GITHUB_ENV
+          GIT_STRIPPED_VERSION=$(git ls-remote --sort='v:refname' --tags | tail -1 | cut -f2 | sed 's/refs\/tags\///g' | cut -c2-)
+          echo "Release channel determined to be $RELEASE_CHANNEL"
+          echo "GIT_LATEST=$LATEST_VERSION" >> $GITHUB_ENV
+          echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
+          echo "GIT_STRIPPED_VERSION=$GIT_STRIPPED_VERSION" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{env.RELEASE_CHANNEL}}-{{sha}}
+            type=semver,pattern={{version}},value=${{env.GIT_STRIPPED_VERSION}}
+            type=raw,value=${{env.RELEASE_CHANNEL}}-{{tag}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{env.RELEASE_CHANNEL}}-latest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}"
+          push: true
+          build-args: |
+            VERSION=${{env.GIT_VERSION}}
+            GIT_COMMITSHA=${GITHUB_SHA::7}
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ secrets.IMAGE_NAME }}
+          readme-filepath: README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.25 as builder 
+FROM --platform=${BUILDPLATFORM} golang:1.25 as builder
+ARG TARGETOS
+ARG TARGETARCH 
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,11 +18,11 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/Makefile
+++ b/Makefile
@@ -151,12 +151,9 @@ PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
 docker-buildx: test ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- docker buildx create --name project-v3-builder
-	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- docker buildx rm project-v3-builder
-	rm Dockerfile.cross
+	docker buildx create --name project-v3-builder --use
+	docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
+	docker buildx rm project-v3-builder
 
 ##@ Deployment
 


### PR DESCRIPTION
## Description
This PR fixes #355

Meshery Operator was only being built for `linux/amd64`. This caused an "Exec format error" on ARM-based hardware (Apple Silicon, AWS Graviton, etc.) because no ARM image manifest existed.

### Changes made:
- Add `.github/workflows/multi-platform.yml` reused from meshery-istio 
  canonical template for multi-platform CI/CD support
- Update Dockerfile to use `BUILDPLATFORM`/`TARGETPLATFORM`/`TARGETOS`/`TARGETARCH` 
  removing all hardcoded platform references
- Simplify Makefile `docker-buildx` target removing `Dockerfile.cross` sed hack

### How it works:
The builder stage always runs natively on the CI host (`BUILDPLATFORM`) for speed,while the Go binary is cross-compiled for he correct target using `GOOS=${TARGETOS} GOARCH=${TARGETARCH}`. Docker Buildx injects these variables automatically per platform.

### Note on sqlite3:
`mattn/go-sqlite3` appears in `go.mod` as `// indirect` (pulled in transitively via meshkit). Since `CGO_ENABLED=0` is set, the operator binary is fully statically linked and sqlite3 is not compiled into it. ARM cross-compilation works cleanly with pure Go static binaries.

### Testing:
- `docker buildx build --platform linux/amd64,linux/arm64` → `27/27 FINISHED` ✅
- `docker inspect` confirms `"Architecture": "arm64"` for ARM image ✅

## Notes for Reviewers
Multi-platform workflow is directly reused from meshery-istio as requested by lee:
https://github.com/meshery-extensions/meshery-istio/blob/master/.github/workflows/multi-platform.yml

## [Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)
- [x] Yes, I signed my commits.