### PR TITLE
fix: update kube-rbac-proxy image from gcr.io/kubebuilder to quay.io/brancz

### DIFF
--- a/bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml
+++ b/bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml
@@ -504,7 +504,7 @@ FnZVJlYWR5ccllPAAAAABJRU5ErkJggg=="
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: quay.io/brancz/kube-rbac-proxy:v0.18.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manifests/default.yaml
+++ b/config/manifests/default.yaml
@@ -402,7 +402,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
## Description
This PR fixes #769

`gcr.io/kubebuilder/kube-rbac-proxy` has been discontinued and the image 
`v0.5.0` is no longer available on the registry, causing the meshery-operator 
pod to get stuck in `ImagePullBackOff` and integration tests to fail on master.

### Changes made:
- Updated `config/default/manager_auth_proxy_patch.yaml`
- Updated `config/manifests/default.yaml`
- Updated `bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml`

All references updated from:
`gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0`
to:
`quay.io/brancz/kube-rbac-proxy:v0.18.0`

### Testing:
- `make integration-tests-setup` completes successfully ✅
- Both `kube-rbac-proxy` and `manager` containers in `Running` state ✅
- `pod/meshery-operator` shows `2/2 Running` ✅

## Notes for Reviewers
`quay.io/brancz/kube-rbac-proxy` is the actively maintained upstream registry.
The `gcr.io/kubebuilder` registry was discontinued in October 2023.

## [Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)
- [x] Yes, I signed my commits.