### PR TITLE
chore: upgrade Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/approve-to-run-ci.yml
+++ b/.github/workflows/approve-to-run-ci.yml
@@ -9,33 +9,29 @@ on:
 
 jobs:
     golangci-lint:
-        strategy:
-          matrix:
-            platform: [ubuntu-24.04]
-            go-version: [1.25.x]
-        runs-on: ${{ matrix.platform }}
+        runs-on: ubuntu-24.04
         steps:
-          - uses: actions/setup-go@v4
+          - name: Checkout code
+            uses: actions/checkout@v4
+          - uses: actions/setup-go@v5
             with:
-              go-version: ${{ matrix.go-version }}
+              go-version-file: go.mod
               cache: true
               cache-dependency-path: go.sum
-          - name: Checkout code
-            uses: actions/checkout@master
           - name: golangci-lint
             uses: golangci/golangci-lint-action@v9
             with:
-              version: v2.8.0
+              version: v2.12.2
     tidy:
         name: Go mod tidy
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@master
+            uses: actions/checkout@v4
           - name: Set up Go
-            uses: actions/setup-go@v4
+            uses: actions/setup-go@v5
             with:
-              go-version: 1.25.x
+              go-version-file: go.mod
               cache: true
               cache-dependency-path: go.sum
           - name: Run go mod tidy
@@ -48,11 +44,11 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@master
+            uses: actions/checkout@v4
           - name: Set up Go
-            uses: actions/setup-go@v4
+            uses: actions/setup-go@v5
             with:
-              go-version: 1.25.x
+              go-version-file: go.mod
               cache: true
               cache-dependency-path: go.sum
           - name: Set up test-env
@@ -69,11 +65,11 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@master
+            uses: actions/checkout@v4
           - name: Set up Go
-            uses: actions/setup-go@v4
+            uses: actions/setup-go@v5
             with:
-              go-version: 1.25.x
+              go-version-file: go.mod
               cache: true
               cache-dependency-path: go.sum
           - name: Build

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -17,16 +17,16 @@ jobs:
         if: github.repository == 'meshery/meshery-operator'
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v4
               # token here with write access to meshery-operator repo
               with:
                   token: ${{ secrets.GH_ACCESS_TOKEN }}
                   ref: "master"
 
             - name: Setup Go
-              uses: actions/setup-go@master
+              uses: actions/setup-go@v5
               with:
-                  go-version: 1.25
+                  go-version-file: go.mod
 
             - name: Run utility
               run: |
@@ -45,7 +45,7 @@ jobs:
 
             # to push changes to meshery docs
             - name: Checkout meshery
-              uses: actions/checkout@master
+              uses: actions/checkout@v4
               with:
                   repository: "meshery/meshery"
                   # token with write access to meshery repository

--- a/.github/workflows/integration-tests-ci.yml
+++ b/.github/workflows/integration-tests-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3 
       - name: Install Kind and kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder 
+FROM golang:1.26.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ kind:
 	chmod +x ./kind
 	sudo mv ./kind /usr/local/bin/kind
 
-SETUP_ENVTEST_VERSION := d4f1e822ca11e9ff149bf2d9b5285f375334eba5
+SETUP_ENVTEST_VERSION := v0.24.1
 
 bin/setup-envtest: $(BIN_DIR)/setup-envtest-$(SETUP_ENVTEST_VERSION) ## Install setup-envtest CLI
 	@ln -sf setup-envtest-$(SETUP_ENVTEST_VERSION) $(BIN_DIR)/setup-envtest

--- a/api/v1alpha1/meshsync_types_test.go
+++ b/api/v1alpha1/meshsync_types_test.go
@@ -29,8 +29,9 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 		PublishingTo string = "Publish for testcase"
 		FileManager  string = "testcase-meshsync"
 
-		Kind       string = "MeshSync"
-		APIVersion string = "meshery.io/v1alpha1"
+		Kind             string = "MeshSync"
+		APIVersion       string = "meshery.io/v1alpha1"
+		defaultNamespace string = "default"
 	)
 
 	var meshSync *MeshSync
@@ -43,8 +44,8 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 				Kind:       Kind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "default",
+				Namespace: defaultNamespace,
+				Name:      defaultNamespace,
 			},
 			Spec: MeshSyncSpec{
 				Size: 2,
@@ -53,8 +54,8 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 						URL: URL,
 					},
 					Native: NativeMeshsyncBroker{
-						Namespace: "default",
-						Name:      "default",
+						Namespace: defaultNamespace,
+						Name:      defaultNamespace,
 					},
 				},
 				WatchList: corev1.ConfigMap{
@@ -64,7 +65,7 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "watch-list",
-						Namespace: "default",
+						Namespace: defaultNamespace,
 					},
 					Data: map[string]string{
 						"blacklist": "",
@@ -75,8 +76,8 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 		}
 
 		typeNamespace = types.NamespacedName{
-			Namespace: "default",
-			Name:      "default",
+			Namespace: defaultNamespace,
+			Name:      defaultNamespace,
 		}
 	})
 
@@ -99,7 +100,7 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 			By("Create the meshsync CRDs first")
 			err := fakeClient.Create(ctx, meshSync)
 			Expect(err).NotTo(HaveOccurred())
-			1
+
 			By("Get the meshsync CRDs")
 			mesheSyncGet := &MeshSync{}
 			err = fakeClient.Get(ctx, typeNamespace, mesheSyncGet)
@@ -119,7 +120,7 @@ var _ = Describe("The test case for the meshsync CRDs", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "watch-list",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Data: map[string]string{
 					"blacklist": "",

--- a/controllers/broker_controller_test.go
+++ b/controllers/broker_controller_test.go
@@ -30,7 +30,13 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 )
 
-const defaultNamespace = "default"
+const (
+	defaultNamespace = "default"
+	testAPIVersion   = "meshery.io/v1alpha1"
+	appLabelKey      = "app"
+	brokerLabelValue = "broker"
+	teamLabelKey     = "team"
+)
 
 var _ = Describe("The test cases for customize resource: Broker's controller ", func() {
 
@@ -56,7 +62,7 @@ var _ = Describe("The test cases for customize resource: Broker's controller ", 
 		namespace = defaultNamespace
 		broker := &v1alpha1.Broker{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "meshery.io/v1alpha1",
+				APIVersion: testAPIVersion,
 				Kind:       "Broker",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -125,14 +131,14 @@ var _ = Describe("The test cases for customize resource: Broker's controller ", 
 					Replicas: &broker.Spec.Size,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "broker",
+							appLabelKey: brokerLabelValue,
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: defaultNamespace,
 							Labels: map[string]string{
-								"app": "broker",
+								appLabelKey: brokerLabelValue,
 							},
 						},
 					},

--- a/controllers/meshsync_controller_test.go
+++ b/controllers/meshsync_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("The test cases for customize resource: MeshSync's controller "
 		It("Getting meshSync resource should be failing", func() {
 			namespace = defaultNamespace
 			meshSync := &v1alpha1.MeshSync{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: namespace}, meshSync)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: defaultNamespace, Namespace: namespace}, meshSync)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -50,11 +50,11 @@ var _ = Describe("The test cases for customize resource: MeshSync's controller "
 		namespace = defaultNamespace
 		meshSync := &v1alpha1.MeshSync{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "meshery.io/v1alpha1",
+				APIVersion: testAPIVersion,
 				Kind:       "MeshSync",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "default",
+				Name:      defaultNamespace,
 				Namespace: namespace,
 			},
 			Spec: v1alpha1.MeshSyncSpec{
@@ -67,16 +67,16 @@ var _ = Describe("The test cases for customize resource: MeshSync's controller "
 	It("Getting meshSync resource should be successful", func() {
 		namespace = defaultNamespace
 		meshSync := &v1alpha1.MeshSync{}
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: namespace}, meshSync)
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: defaultNamespace, Namespace: namespace}, meshSync)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(meshSync.Spec.Size).To(Equal(int32(1)))
 	})
 
 	It("Updating meshSync resource should be successful", func() {
-		namespace = "default"
+		namespace = defaultNamespace
 		Eventually(func() error {
 			meshSync := &v1alpha1.MeshSync{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: namespace}, meshSync)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: defaultNamespace, Namespace: namespace}, meshSync)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ var _ = Describe("The test cases for customize resource: MeshSync's controller "
 
 		By("Checking if the meshSync resource is updated")
 		meshSync := &v1alpha1.MeshSync{}
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: namespace}, meshSync)
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: defaultNamespace, Namespace: namespace}, meshSync)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(meshSync.Spec.Size).To(Equal(int32(2)))
 	})
@@ -95,7 +95,7 @@ var _ = Describe("The test cases for customize resource: MeshSync's controller "
 		It("Deleting meshSync resource should be succeeding", func() {
 			namespace = defaultNamespace
 			meshSync := &v1alpha1.MeshSync{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: "default", Namespace: namespace}, meshSync)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: defaultNamespace, Namespace: namespace}, meshSync)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(k8sClient.Delete(ctx, meshSync)).Should(Succeed())
 		})

--- a/controllers/update_reconcile_suite_test.go
+++ b/controllers/update_reconcile_suite_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Controller update reconciliation", func() {
 
 		broker := &mesheryv1alpha1.Broker{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "meshery.io/v1alpha1",
+				APIVersion: testAPIVersion,
 				Kind:       "Broker",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -77,7 +77,7 @@ var _ = Describe("Controller update reconciliation", func() {
 
 		meshsync := &mesheryv1alpha1.MeshSync{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "meshery.io/v1alpha1",
+				APIVersion: testAPIVersion,
 				Kind:       "MeshSync",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/update_sync_unit_test.go
+++ b/controllers/update_sync_unit_test.go
@@ -8,6 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const oldAnnotation = "old"
+
 func TestSyncBrokerStatefulSet(t *testing.T) {
 	const newAnnotation = "new"
 	one := int32(1)
@@ -15,18 +17,18 @@ func TestSyncBrokerStatefulSet(t *testing.T) {
 
 	existing := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": "old"},
-			Annotations: map[string]string{"team": "old"},
+			Labels:      map[string]string{appLabelKey: oldAnnotation},
+			Annotations: map[string]string{teamLabelKey: oldAnnotation},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:    &one,
-			ServiceName: "old",
+			ServiceName: oldAnnotation,
 		},
 	}
 	desired := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": newAnnotation},
-			Annotations: map[string]string{"team": newAnnotation},
+			Labels:      map[string]string{appLabelKey: newAnnotation},
+			Annotations: map[string]string{teamLabelKey: newAnnotation},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:    &two,
@@ -37,10 +39,10 @@ func TestSyncBrokerStatefulSet(t *testing.T) {
 	if changed := syncBrokerStatefulSet(existing, desired); !changed {
 		t.Fatal("expected statefulset sync to report changes")
 	}
-	if existing.Labels["app"] != newAnnotation {
+	if existing.Labels[appLabelKey] != newAnnotation {
 		t.Fatalf("expected labels to be updated, got %v", existing.Labels)
 	}
-	if existing.Annotations["team"] != newAnnotation {
+	if existing.Annotations[teamLabelKey] != newAnnotation {
 		t.Fatalf("expected annotations to be updated, got %v", existing.Annotations)
 	}
 	if existing.Spec.Replicas == nil || *existing.Spec.Replicas != two {
@@ -58,12 +60,12 @@ func TestSyncBrokerService(t *testing.T) {
 	const newAnnotation = "new"
 	existing := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": "old"},
-			Annotations: map[string]string{"team": "old"},
+			Labels:      map[string]string{appLabelKey: oldAnnotation},
+			Annotations: map[string]string{teamLabelKey: oldAnnotation},
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{"app": "old"},
+			Selector: map[string]string{appLabelKey: oldAnnotation},
 			Ports: []corev1.ServicePort{
 				{Name: "client", Port: 4222},
 			},
@@ -72,12 +74,12 @@ func TestSyncBrokerService(t *testing.T) {
 	}
 	desired := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": newAnnotation},
-			Annotations: map[string]string{"team": newAnnotation},
+			Labels:      map[string]string{appLabelKey: newAnnotation},
+			Annotations: map[string]string{teamLabelKey: newAnnotation},
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeLoadBalancer,
-			Selector: map[string]string{"app": newAnnotation},
+			Selector: map[string]string{appLabelKey: newAnnotation},
 			Ports: []corev1.ServicePort{
 				{Name: "client", Port: 5222},
 			},
@@ -87,10 +89,10 @@ func TestSyncBrokerService(t *testing.T) {
 	if changed := syncBrokerService(existing, desired); !changed {
 		t.Fatal("expected service sync to report changes")
 	}
-	if existing.Labels["app"] != newAnnotation {
+	if existing.Labels[appLabelKey] != newAnnotation {
 		t.Fatalf("expected labels to be updated, got %v", existing.Labels)
 	}
-	if existing.Annotations["team"] != newAnnotation {
+	if existing.Annotations[teamLabelKey] != newAnnotation {
 		t.Fatalf("expected annotations to be updated, got %v", existing.Annotations)
 	}
 	if existing.Spec.Type != corev1.ServiceTypeLoadBalancer {
@@ -99,7 +101,7 @@ func TestSyncBrokerService(t *testing.T) {
 	if existing.Spec.Ports[0].Port != 5222 {
 		t.Fatalf("expected service port to be updated, got %d", existing.Spec.Ports[0].Port)
 	}
-	if existing.Spec.Selector["app"] != newAnnotation {
+	if existing.Spec.Selector[appLabelKey] != newAnnotation {
 		t.Fatalf("expected selector to be updated, got %v", existing.Spec.Selector)
 	}
 	if existing.Spec.ClusterIP != "10.0.0.1" {
@@ -114,16 +116,16 @@ func TestSyncBrokerConfigMap(t *testing.T) {
 	const newAnnotation = "new"
 	existing := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": "old"},
-			Annotations: map[string]string{"team": "old"},
+			Labels:      map[string]string{appLabelKey: oldAnnotation},
+			Annotations: map[string]string{teamLabelKey: oldAnnotation},
 		},
-		Data:       map[string]string{"config": "old"},
-		BinaryData: map[string][]byte{"bin": []byte("old")},
+		Data:       map[string]string{"config": oldAnnotation},
+		BinaryData: map[string][]byte{"bin": []byte(oldAnnotation)},
 	}
 	desired := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": newAnnotation},
-			Annotations: map[string]string{"team": newAnnotation},
+			Labels:      map[string]string{appLabelKey: newAnnotation},
+			Annotations: map[string]string{teamLabelKey: newAnnotation},
 		},
 		Data:       map[string]string{"config": newAnnotation},
 		BinaryData: map[string][]byte{"bin": []byte(newAnnotation)},
@@ -150,8 +152,8 @@ func TestSyncMeshsyncDeployment(t *testing.T) {
 
 	existing := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": "old"},
-			Annotations: map[string]string{"team": "old"},
+			Labels:      map[string]string{appLabelKey: oldAnnotation},
+			Annotations: map[string]string{teamLabelKey: oldAnnotation},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &one,
@@ -159,8 +161,8 @@ func TestSyncMeshsyncDeployment(t *testing.T) {
 	}
 	desired := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": newAnnotation},
-			Annotations: map[string]string{"team": newAnnotation},
+			Labels:      map[string]string{appLabelKey: newAnnotation},
+			Annotations: map[string]string{teamLabelKey: newAnnotation},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &two,
@@ -170,10 +172,10 @@ func TestSyncMeshsyncDeployment(t *testing.T) {
 	if changed := syncMeshsyncDeployment(existing, desired); !changed {
 		t.Fatal("expected deployment sync to report changes")
 	}
-	if existing.Labels["app"] != newAnnotation {
+	if existing.Labels[appLabelKey] != newAnnotation {
 		t.Fatalf("expected labels to be updated, got %v", existing.Labels)
 	}
-	if existing.Annotations["team"] != newAnnotation {
+	if existing.Annotations[teamLabelKey] != newAnnotation {
 		t.Fatalf("expected annotations to be updated, got %v", existing.Annotations)
 	}
 	if existing.Spec.Replicas == nil || *existing.Spec.Replicas != two {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/meshery-operator
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -95,7 +95,7 @@ func GetEndpoint(ctx context.Context, m *mesheryv1alpha1.Broker, client client.C
 	opts := &meshkitkube.ServiceOptions{
 		Name:         m.Name,
 		Namespace:    m.Namespace,
-		PortSelector: "client",
+		PortSelector: clientPortName,
 		APIServerURL: url,
 		WorkerNodeIP: "localhost",
 	}

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -91,14 +91,14 @@ var _ = Describe("Broker funtions test cases", func() {
 					Replicas: &m.Spec.Size,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "broker",
+							appLabelKey: brokerComponent,
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: name,
 							Labels: map[string]string{
-								"app": "broker",
+								appLabelKey: brokerComponent,
 							},
 						},
 					},

--- a/pkg/broker/resources.go
+++ b/pkg/broker/resources.go
@@ -7,6 +7,17 @@ import (
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	mesheryName       = "meshery"
+	appLabelKey       = "app"
+	componentLabelKey = "component"
+	brokerComponent   = "broker"
+	natsServiceName   = "meshery-nats"
+	clientPortName    = "client"
+	configVolumeName  = "config-volume"
+	pidVolumeName     = "pid"
+)
+
 var (
 	val1    int32 = 1
 	val60   int64 = 60
@@ -20,7 +31,7 @@ var (
 	valtrue bool = true
 
 	MesheryLabel = map[string]string{
-		"app": "meshery",
+		appLabelKey: mesheryName,
 	}
 
 	MesheryAnnotation = map[string]string{
@@ -28,8 +39,8 @@ var (
 	}
 
 	BrokerLabel = map[string]string{
-		"app":       MesheryLabel["app"],
-		"component": "broker",
+		appLabelKey:       MesheryLabel[appLabelKey],
+		componentLabelKey: brokerComponent,
 	}
 
 	PrometheusAnnotation = map[string]string{
@@ -41,7 +52,7 @@ var (
 
 	NatsConfigMap = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "meshery",
+			Namespace: mesheryName,
 			Name:      "meshery-nats-config",
 			Labels:    BrokerLabel,
 		},
@@ -60,7 +71,7 @@ include "accounts/resolver.conf"`,
 
 	AccountsConfigMap = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "meshery",
+			Namespace: mesheryName,
 			Name:      "meshery-nats-accounts",
 			Labels:    BrokerLabel,
 		},
@@ -75,15 +86,15 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 
 	Service = &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   "meshery",
-			Name:        "meshery-nats",
+			Namespace:   mesheryName,
+			Name:        natsServiceName,
 			Labels:      BrokerLabel,
 			Annotations: MesheryAnnotation,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name: "client",
+					Name: clientPortName,
 					Port: val4222,
 				},
 				{
@@ -114,8 +125,8 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 
 	StatefulSet = &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   "meshery",
-			Name:        "meshery-nats",
+			Namespace:   mesheryName,
+			Name:        natsServiceName,
 			Labels:      BrokerLabel,
 			Annotations: MesheryAnnotation,
 		},
@@ -124,15 +135,15 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 			Selector: &metav1.LabelSelector{
 				MatchLabels: BrokerLabel,
 			},
-			ServiceName: "meshery-nats",
+			ServiceName: natsServiceName,
 			Template:    PodTemplate,
 		},
 	}
 
 	PodTemplate = corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   "meshery",
-			Name:        "meshery-nats",
+			Namespace:   mesheryName,
+			Name:        natsServiceName,
 			Labels:      BrokerLabel,
 			Annotations: PrometheusAnnotation,
 		},
@@ -140,7 +151,7 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 			ServiceAccountName: "meshery-operator",
 			Volumes: []corev1.Volume{
 				{
-					Name: "config-volume",
+					Name: configVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
@@ -150,7 +161,7 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 					},
 				},
 				{
-					Name: "pid",
+					Name: pidVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -175,7 +186,7 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Ports: []corev1.ContainerPort{
 						{
-							Name: "client",
+							Name: clientPortName,
 
 							ContainerPort: val4222,
 						},
@@ -231,11 +242,11 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "config-volume",
+							Name:      configVolumeName,
 							MountPath: "/etc/nats-config",
 						},
 						{
-							Name:      "pid",
+							Name:      pidVolumeName,
 							MountPath: "/var/run/nats",
 						},
 						{
@@ -286,11 +297,11 @@ ACSU3Q6LTLBVLGAQUONAGXJHVNWGSKKAUA7IY5TB4Z7PLEKSR5O6JTGR: eyJ0eXAiOiJqd3QiLCJhbG
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      "config-volume",
+							Name:      configVolumeName,
 							MountPath: "/etc/nats-config",
 						},
 						{
-							Name:      "pid",
+							Name:      pidVolumeName,
 							MountPath: "/var/run/nats",
 						},
 					},

--- a/pkg/meshsync/resources.go
+++ b/pkg/meshsync/resources.go
@@ -23,6 +23,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	appLabelKey     = "app"
+	componentKey    = "component"
+	mesheryName     = "meshery"
+	meshsyncBinary  = "./meshery-meshsync"
+	meshsyncName    = "meshery-meshsync"
+	meshsyncService = "meshsync"
+)
+
 var (
 	val1     int32 = 1
 	val60    int64 = 60
@@ -31,12 +40,12 @@ var (
 	valtrue bool = true
 
 	MesheryLabel = map[string]string{
-		"app": "meshery",
+		appLabelKey: mesheryName,
 	}
 
 	MeshSyncLabel = map[string]string{
-		"app":       MesheryLabel["app"],
-		"component": "meshsync",
+		appLabelKey:  MesheryLabel[appLabelKey],
+		componentKey: meshsyncService,
 	}
 
 	MesheryAnnotation = map[string]string{
@@ -51,7 +60,7 @@ var (
 
 	Deployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "meshery-meshsync",
+			Name:        meshsyncName,
 			Labels:      MeshSyncLabel,
 			Annotations: MesheryAnnotation,
 		},
@@ -66,7 +75,7 @@ var (
 
 	PodTemplate = corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "meshery-meshsync",
+			Name:        meshsyncName,
 			Labels:      MeshSyncLabel,
 			Annotations: MesheryAnnotation,
 		},
@@ -87,7 +96,7 @@ var (
 						},
 					},
 					Command: []string{
-						"./meshery-meshsync",
+						meshsyncBinary,
 					},
 					Env: []corev1.EnvVar{
 						{
@@ -113,7 +122,7 @@ var (
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{
 								Command: []string{
-									"./meshery-meshsync",
+									meshsyncBinary,
 									"-h",
 								},
 							},
@@ -127,7 +136,7 @@ var (
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{
 								Command: []string{
-									"./meshery-meshsync",
+									meshsyncBinary,
 									"-h",
 								},
 							},


### PR DESCRIPTION
## Summary
- Upgrade the module and Docker builder image to Go 1.26.4.
- Update CI Go setup to read from go.mod where a single toolchain version is expected.
- Move golangci-lint to v2.12.2 for Go 1.26 compatibility.
- Update setup-envtest so the test environment can fetch Kubernetes 1.30.0 assets.
- Clean up repeated constants and a stray test literal surfaced by the updated lint/toolchain checks.

## Validation
- go mod tidy
- make test-env
- go build ./...
- go test ./...
- go vet ./...
- golangci-lint run -c .golangci.yml -v ./...
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/approve-to-run-ci.yml .github/workflows/integration-tests-ci.yml .github/workflows/error-ref-publisher.yaml

Related to meshery/meshery#19875