### PR TITLE
Bump Go version to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder 
+FROM golang:1.26.4 as builder 
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/meshery-operator
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Description

This PR bumps the Go language version to `1.26.4` to keep the project's dependencies and build environments up to date.

**Changes include:**
* Updated the `go` directive in `go.mod` files to `1.26.4`.
* Updated the `golang` base image tags in `Dockerfile`s to `1.26.4`.

## Related Issue(s)
* Nil

## Related Issue(s)
* Addresses meshery/meshery#19875

## Type of change
- [x] Chore (updates to build processes)


