### PR TITLE
feat: Add OpenAPI v3 validation markers to MeshSync and Broker CRDs

### DIFF
--- a/api/v1alpha1/broker_types.go
+++ b/api/v1alpha1/broker_types.go
@@ -26,7 +26,9 @@ type BrokerSpec struct {
 }
 
 type Endpoint struct {
+	// +kubebuilder:validation:Format=uri
 	Internal string `json:"internal,omitempty" yaml:"internal,omitempty"`
+	// +kubebuilder:validation:Format=uri
 	External string `json:"external,omitempty" yaml:"external,omitempty"`
 }
 

--- a/api/v1alpha1/meshsync_types.go
+++ b/api/v1alpha1/meshsync_types.go
@@ -22,6 +22,7 @@ import (
 )
 
 type CustomMeshsyncBroker struct {
+	// +kubebuilder:validation:Format=uri
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 


### PR DESCRIPTION
#### Current Behavior
Currently, the CRDs for MeshSync and Broker lack OpenAPI v3 validation constraints. The Go structs are defined with basic data types without boundaries.

#### Desired Behavior
The Kubernetes API server should reject invalid custom resources by adding standard Kubebuilder validation markers.

#### Implementation
Added Kubebuilder validation markers to the types and ran controller-gen to regenerate the CRDs.

#### Acceptance Tests
- Generated CRDs contain validation blocks.
- Attempting to apply invalid fields fails at the API server level.