### PR TITLE
fix: auto-configure KUBEBUILDER_ASSETS in make test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,15 @@ Please do! Thank you for your help in improving Meshery! :balloon:
 
  Find the complete set of contributor guides at https://docs.meshery.io/project/contributing
 
+
+## Running Tests Locally
+
+```bash
+# Install envtest binaries and run tests
+make test
+
+# Run tests with coverage
+make coverage
+```
+
+If you see `etcd not found in PATH`, ensure you run `make test` (which handles envtest setup automatically) rather than `go test ./...` directly.

--- a/Makefile
+++ b/Makefile
@@ -261,9 +261,14 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 # Test coverage
+# Run tests with envtest binaries
+.PHONY: test
+test: envtest
+	KUBEBUILDER_ASSETS="$(shell $(BIN_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR) -p path)" go test ./... -coverprofile cover.out
+
 .PHONY: coverage
-coverage: test-env
-	go test -v ./... -coverprofile cover.out
+coverage: envtest
+	KUBEBUILDER_ASSETS="$(shell $(BIN_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR) -p path)" go test -v ./... -coverprofile cover.out
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: kind
@@ -284,9 +289,8 @@ $(BIN_DIR)/setup-envtest-$(SETUP_ENVTEST_VERSION):
 
 # Setting test envrioment
 .PHONY: test-env
-test-env:
-	make bin/setup-envtest
-	bin/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR)
+test-env: envtest
+	@echo "Test environment ready. Use 'make test' to run tests."
 
 ##@ Integration Tests
 


### PR DESCRIPTION
Fixes #777

The `make test` target was missing, causing `KUBEBUILDER_ASSETS` to not be exported when running tests locally. This led to envtest control plane startup failures with 'etcd not found in PATH' errors.

Changes:
- Added new `test` target that depends on `envtest` and automatically exports `KUBEBUILDER_ASSETS` via `setup-envtest -p path`
- Fixed `coverage` target to use `envtest` dependency and export `KUBEBUILDER_ASSETS`
- Refactored `test-env` to depend on `envtest` for clarity
- Updated CONTRIBUTING.md with "Running Tests Locally" documentation
