### PR TITLE
feat: add Prometheus metrics for operator reconciliation

### DIFF
--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	mesheryv1alpha1 "github.com/meshery/meshery-operator/api/v1alpha1"
 	brokerpackage "github.com/meshery/meshery-operator/pkg/broker"
+	"github.com/meshery/meshery-operator/pkg/metrics"
 	"github.com/meshery/meshery-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,8 @@ type BrokerReconciler struct {
 
 const (
 	brokerFinalizer = "broker.meshery.io/finalizer"
+	// brokerControllerName labels this controller's reconciliation metrics.
+	brokerControllerName = "broker"
 )
 
 // +kubebuilder:rbac:groups=meshery.io,resources=brokers,verbs=get;list;watch;create;update;patch;delete
@@ -59,7 +62,16 @@ const (
 // +kubebuilder:rbac:groups="",resources=services;configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is the main reconciliation loop
-func (r *BrokerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *BrokerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reconcileErr error) {
+	start := time.Now()
+	defer func() {
+		metrics.ReconcileTotal.WithLabelValues(brokerControllerName).Inc()
+		metrics.ReconcileDuration.WithLabelValues(brokerControllerName).Observe(time.Since(start).Seconds())
+		if reconcileErr != nil {
+			metrics.ReconcileErrors.WithLabelValues(brokerControllerName).Inc()
+		}
+	}()
+
 	log := r.Log.WithValues("controller", "Broker", "namespace", req.NamespacedName)
 	log.Info("Reconciling broker")
 
@@ -75,8 +87,8 @@ func (r *BrokerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// finalizer exists
-	if result, err := r.ensureFinalizer(ctx, log, baseResource); err != nil || result.RequeueAfter > 0 {
-		return result, err
+	if res, err := r.ensureFinalizer(ctx, log, baseResource); err != nil || res.RequeueAfter > 0 {
+		return res, err
 	}
 
 	// main reconciliation

--- a/controllers/meshsync_controller.go
+++ b/controllers/meshsync_controller.go
@@ -24,6 +24,7 @@ import (
 	mesheryv1alpha1 "github.com/meshery/meshery-operator/api/v1alpha1"
 	brokerpackage "github.com/meshery/meshery-operator/pkg/broker"
 	meshsyncpackage "github.com/meshery/meshery-operator/pkg/meshsync"
+	"github.com/meshery/meshery-operator/pkg/metrics"
 	"github.com/meshery/meshery-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -50,6 +51,8 @@ type MeshSyncReconciler struct {
 
 const (
 	meshsyncFinalizer = "meshsync.meshery.io/finalizer"
+	// meshsyncControllerName labels this controller's reconciliation metrics.
+	meshsyncControllerName = "meshsync"
 )
 
 // +kubebuilder:rbac:groups=meshery.io,resources=meshsyncs,verbs=get;list;watch;create;update;patch;delete
@@ -60,7 +63,16 @@ const (
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles the MeshSync resource
-func (r *MeshSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MeshSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reconcileErr error) {
+	start := time.Now()
+	defer func() {
+		metrics.ReconcileTotal.WithLabelValues(meshsyncControllerName).Inc()
+		metrics.ReconcileDuration.WithLabelValues(meshsyncControllerName).Observe(time.Since(start).Seconds())
+		if reconcileErr != nil {
+			metrics.ReconcileErrors.WithLabelValues(meshsyncControllerName).Inc()
+		}
+	}()
+
 	log := r.Log
 	log = log.WithValues("controller", "MeshSync")
 	log = log.WithValues("namespace", req.NamespacedName)
@@ -77,8 +89,8 @@ func (r *MeshSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.handleDeletion(ctx, log, baseResource)
 	}
 
-	if result, err := r.ensureFinalizer(ctx, log, baseResource); err != nil || result.RequeueAfter > 0 {
-		return result, err
+	if res, err := r.ensureFinalizer(ctx, log, baseResource); err != nil || res.RequeueAfter > 0 {
+		return res, err
 	}
 	return r.performReconciliation(ctx, log, baseResource, req)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ the [Meshery docs site](https://docs.meshery.io).
 | [development.md](development.md) | Local setup, the `go/v4` project layout, the Makefile targets, tool versions, and how to build/run the operator. |
 | [testing.md](testing.md) | The three test tiers (unit, envtest, kind e2e) and how to run each. |
 | [errors.md](errors.md) | The error-handling convention (MeshKit structured errors) and how to add a new error. |
+| [metrics.md](metrics.md) | The Prometheus reconciliation metrics, how they are wired to the manager endpoint, and how to add a metric. |
 | [proposals/operator-modernization-plan.md](proposals/operator-modernization-plan.md) | The phased modernization plan and the eight workstreams it is delivered in. |
 
 ## Repository layout (Kubebuilder `go/v4`)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,143 @@
+# Metrics
+
+The operator exports Prometheus metrics for its reconciliation loops so that
+controller throughput, error rate, and latency are observable in a running
+cluster. This document covers what is exported, how it is wired, and how to add a
+new metric. It pairs with the [architecture](architecture.md) overview of the two
+controllers.
+
+## What is exported
+
+The `pkg/metrics` package defines three metric vectors, each partitioned by a
+single `controller` label (`"broker"` or `"meshsync"`):
+
+| Metric | Type | What it measures |
+|--------|------|------------------|
+| `meshery_operator_reconcile_total` | `CounterVec` | Total reconciliations per controller. |
+| `meshery_operator_reconcile_errors_total` | `CounterVec` | Reconciliations that returned a non-nil error, per controller. |
+| `meshery_operator_reconcile_duration_seconds` | `HistogramVec` | Reconciliation wall-clock latency per controller (default Prometheus buckets). |
+
+All three carry the `meshery_operator_` prefix and the same `controller` label,
+so they line up in queries — e.g. the per-controller error ratio is
+`rate(meshery_operator_reconcile_errors_total[5m]) /
+rate(meshery_operator_reconcile_total[5m])`, and a latency SLI is
+`histogram_quantile(0.99, rate(meshery_operator_reconcile_duration_seconds_bucket[5m]))`.
+
+These sit alongside the controller-runtime built-ins (`controller_runtime_*`,
+`workqueue_*`, `rest_client_*`, Go runtime/process metrics) that the manager
+already exposes — our metrics describe *our* reconcile bodies, the built-ins
+describe the queue and client machinery underneath them.
+
+## How it is wired
+
+There is no manual registration or HTTP wiring to maintain. Two mechanisms do the
+work:
+
+1. **Registration** — `pkg/metrics/metrics.go` registers the three vectors with
+   the **controller-runtime** registry (`sigs.k8s.io/controller-runtime/pkg/metrics`)
+   in its `init()` via `ctrlmetrics.Registry.MustRegister(...)`. That registry is
+   the one the manager already serves, so registering there means the metrics
+   appear on the existing endpoint automatically.
+
+2. **Exposure** — `cmd/main.go` configures the manager's metrics server
+   (`server.Options{BindAddress: metricsAddr}`), which defaults to `:8080` and is
+   overridable with `--metrics-addr`. The metrics are scraped from
+   `http://<pod>:8080/metrics`.
+
+   > Today this endpoint is plain HTTP (insecure). Metrics TLS + `authn/authz`
+   > hardening, and shipping the (currently commented-out) `config/prometheus`
+   > `ServiceMonitor`, are tracked under **WS-5** in the
+   > [modernization plan](proposals/operator-modernization-plan.md) — until then,
+   > scraping is via direct pod access, not a `ServiceMonitor`.
+
+### Instrumentation in the controllers
+
+Each `Reconcile` is instrumented with a single `defer` at the top of the method,
+using **named return values** so the deferred closure can read the outcome
+without rewriting any of the individual `return` sites:
+
+```go
+func (r *BrokerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reconcileErr error) {
+    start := time.Now()
+    defer func() {
+        metrics.ReconcileTotal.WithLabelValues(brokerControllerName).Inc()
+        metrics.ReconcileDuration.WithLabelValues(brokerControllerName).Observe(time.Since(start).Seconds())
+        if reconcileErr != nil {
+            metrics.ReconcileErrors.WithLabelValues(brokerControllerName).Inc()
+        }
+    }()
+    // ... reconcile body, unchanged ...
+}
+```
+
+Why this shape:
+
+- **One defer, every exit path.** Reconcile has several early returns (not found,
+  finalizer requeue, reconcile error). A single deferred closure records the count
+  and duration on *all* of them and bumps the error counter only when
+  `reconcileErr` is non-nil — no per-return bookkeeping to forget.
+- **Named returns are required for it to work.** The closure reads `reconcileErr`
+  after the body has set it. Switching to named returns is the only control-flow
+  change; it also means an inner `result` variable (e.g. from `ensureFinalizer`)
+  must be renamed (`res`) to avoid shadowing the named return — `govet`'s shadow
+  analyzer flags this.
+- **Controller name is a constant.** `brokerControllerName` / `meshsyncControllerName`
+  are declared next to each controller's other constants. They double as the label
+  value and satisfy `goconst` (the string would otherwise repeat).
+
+## Adding a metric
+
+1. Define the metric vector in `pkg/metrics/metrics.go` as a package-level `var`,
+   with a `meshery_operator_` name prefix and a clear `Help` string. Reuse the
+   `controllerLabel` constant if it is per-controller; introduce a new label
+   constant if you need a different dimension (keep cardinality bounded — labels
+   must be a small, closed set, never user input or resource names).
+2. Add it to the `MustRegister(...)` call in `init()`.
+3. Record from the relevant code path. For per-reconcile signals, extend the
+   existing `defer` closure rather than scattering new call sites.
+4. Add a case to `pkg/metrics/metrics_test.go` (see below). New behavior gets a
+   test case in the existing suite, not a new file — same convention as the rest
+   of the repo ([testing.md](testing.md)).
+
+## Tests
+
+`pkg/metrics/metrics_test.go` uses `client_golang`'s `testutil` helpers and covers
+three things:
+
+- **Counters increment** independently per `controller` label
+  (`testutil.ToFloat64`).
+- **The histogram records** observations (`testutil.CollectAndCount`).
+- **Registration** — the acceptance criterion. It gathers from the
+  controller-runtime registry (`ctrlmetrics.Registry.Gather()`) and asserts all
+  three metric families are present, because registering with *that* registry is
+  exactly what exposes them on the operator's endpoint.
+
+These are unit tests with no control plane:
+
+```bash
+go test ./pkg/metrics/...
+```
+
+## Verifying locally
+
+Run the manager and curl the endpoint:
+
+```bash
+make run    # serves metrics on :8080 by default
+curl -s localhost:8080/metrics | grep meshery_operator_
+```
+
+The series only appear after the corresponding controller has reconciled at least
+once (counters and histograms are created lazily on first `WithLabelValues`), so
+apply a `Broker`/`MeshSync` sample (or wait for an existing one to reconcile)
+before scraping.
+
+## Background
+
+This metrics set fixes [#779](https://github.com/meshery/meshery-operator/issues/779)
+and continues the work begun in
+[#780](https://github.com/meshery/meshery-operator/pull/780), rebased onto the
+post-Kubebuilder-`go/v4` (WS-1) layout. The metric naming and the defer-based
+timing pattern carry over from that PR; the Makefile/`CONTRIBUTING.md` edits from
+#780 were dropped because WS-1 already provides the envtest-aware `make test`
+target and this contributor docs set.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/meshery/meshkit v0.8.64
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
+	github.com/prometheus/client_golang v1.23.2
 	k8s.io/api v0.35.0
 	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -95,6 +96,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
@@ -119,7 +121,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,64 @@
+/*
+Copyright Meshery Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics defines and registers the Prometheus metrics exported by the
+// Meshery Operator. Metrics are registered with the controller-runtime metrics
+// registry so they are exposed automatically on the manager's metrics endpoint
+// (default :8080/metrics) without any additional wiring.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// controllerLabel partitions the reconciliation metrics by controller (e.g.
+// "broker", "meshsync").
+const controllerLabel = "controller"
+
+var (
+	// ReconcileTotal counts reconciliations per controller.
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "meshery_operator_reconcile_total",
+			Help: "Total number of reconciliations per controller.",
+		},
+		[]string{controllerLabel},
+	)
+
+	// ReconcileErrors counts reconciliations that returned an error, per controller.
+	ReconcileErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "meshery_operator_reconcile_errors_total",
+			Help: "Total number of reconciliation errors per controller.",
+		},
+		[]string{controllerLabel},
+	)
+
+	// ReconcileDuration tracks reconciliation latency in seconds, per controller.
+	ReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "meshery_operator_reconcile_duration_seconds",
+			Help:    "Reconciliation duration in seconds per controller.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{controllerLabel},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(ReconcileTotal, ReconcileErrors, ReconcileDuration)
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright Meshery Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// TestReconcileCountersIncrement verifies the counter vectors track values
+// independently per controller label.
+func TestReconcileCountersIncrement(t *testing.T) {
+	ReconcileTotal.WithLabelValues("broker").Inc()
+	if got := testutil.ToFloat64(ReconcileTotal.WithLabelValues("broker")); got != 1 {
+		t.Errorf("ReconcileTotal{controller=broker} = %v, want 1", got)
+	}
+
+	ReconcileErrors.WithLabelValues("meshsync").Inc()
+	if got := testutil.ToFloat64(ReconcileErrors.WithLabelValues("meshsync")); got != 1 {
+		t.Errorf("ReconcileErrors{controller=meshsync} = %v, want 1", got)
+	}
+}
+
+// TestReconcileDurationObserve verifies the histogram records observations.
+func TestReconcileDurationObserve(t *testing.T) {
+	ReconcileDuration.WithLabelValues("broker").Observe(0.5)
+	if count := testutil.CollectAndCount(ReconcileDuration); count == 0 {
+		t.Error("ReconcileDuration recorded no series after Observe")
+	}
+}
+
+// TestMetricsRegistered asserts that every metric is registered with the
+// controller-runtime registry, which is what exposes them on the operator's
+// metrics endpoint.
+func TestMetricsRegistered(t *testing.T) {
+	// Touch each metric so its family appears in the gathered output.
+	ReconcileTotal.WithLabelValues("registered").Inc()
+	ReconcileErrors.WithLabelValues("registered").Inc()
+	ReconcileDuration.WithLabelValues("registered").Observe(0.1)
+
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics from controller-runtime registry: %v", err)
+	}
+
+	want := map[string]bool{
+		"meshery_operator_reconcile_total":            false,
+		"meshery_operator_reconcile_errors_total":     false,
+		"meshery_operator_reconcile_duration_seconds": false,
+	}
+	for _, family := range families {
+		if _, ok := want[family.GetName()]; ok {
+			want[family.GetName()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("metric %q is not registered with the controller-runtime registry", name)
+		}
+	}
+}


### PR DESCRIPTION
f**Description**

This PR fixes #779.

Adds reconciliation observability to the operator and continues the work started in #780 by @Chaithanya5gif, rebased onto the post-Kubebuilder-go/v4 (WS-1) layout per the request on that PR.

A new `pkg/metrics` package registers three metrics with the controller-runtime registry, so they are exposed automatically on the manager's existing metrics endpoint (default `:8080/metrics`) with no extra wiring:

- `meshery_operator_reconcile_total{controller}`
- `meshery_operator_reconcile_errors_total{controller}`
- `meshery_operator_reconcile_duration_seconds{controller}`

The `BrokerReconciler` and `MeshSyncReconciler` are instrumented via a deferred closure that records the count and duration on every reconcile and increments the error counter only when a non-nil error is returned.

**Notes for Reviewers**

Carried over from #780 (metric naming and the defer-based timing pattern), with the following review changes applied:

- **Dropped the Makefile and `CONTRIBUTING.md` changes** from #780 — WS-1 already provides the envtest-aware `make test` target and contributor docs (`docs/testing.md`), so those edits are now obsolete and would conflict.
- **Named return values** (`result`, `reconcileErr`) keep the instrumentation in a single `defer` at the top of `Reconcile` instead of rewriting every return site, minimizing churn in the control flow.
- **Lint-clean:** extracted controller-name and label constants to satisfy `goconst`, grouped imports for `gci`/`goimports`, added the Apache license headers, and renamed an inner `result` to avoid shadowing under `govet`'s shadow analyzer.
- **Tests** assert all three metrics are registered with the controller-runtime registry (the acceptance criterion) and that the counters and histogram record values.

Verified locally: `gofmt`, `go vet`, `go build ./...`, `golangci-lint v2.12.2 run ./...` (0 issues), and the full unit/envtest suite (`make test`) all pass.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
