### PR TITLE
[WS-3a] Adopt MeshKit structured errors across operator registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,14 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 tidy: ## Run go mod tidy against code.
 	go mod tidy
 
+.PHONY: error
+error: ## Analyze MeshKit error codes (read-only); writes errorutil_*.json to ./helpers.
+	go run github.com/meshery/meshkit/cmd/errorutil -d . analyze -i ./helpers -o ./helpers
+
+.PHONY: error-util
+error-util: ## Assign/update MeshKit error codes and regenerate the error reference export.
+	go run github.com/meshery/meshkit/cmd/errorutil -d . update -i ./helpers -o ./helpers
+
 .PHONY: test
 test: manifests generate fmt vet test-env ## Run tests.
 	KUBEBUILDER_ASSETS="$$(bin/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN_DIR) -p path)" \

--- a/controllers/broker_controller.go
+++ b/controllers/broker_controller.go
@@ -217,7 +217,7 @@ func (r *BrokerReconciler) getBrokerEndpoint(ctx context.Context, log logr.Logge
 func (r *BrokerReconciler) patchBrokerStatus(ctx context.Context, log logr.Logger, baseResource *mesheryv1alpha1.Broker) (ctrl.Result, error) {
 	patch, err := utils.Marshal(baseResource)
 	if err != nil {
-		err = ErrUpdateResource(err)
+		err = ErrMarshal(err)
 		log.Error(err, "Unable to marshal broker resource")
 		return ctrl.Result{}, err
 	}

--- a/controllers/error.go
+++ b/controllers/error.go
@@ -16,11 +16,11 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
+	meshkiterrors "github.com/meshery/meshkit/errors"
 )
 
-// Error codes
-// @Aisuko Is there any way to make this more flexible?
+// Error codes. Codes are unique within this component; allocate the next free
+// code from helpers/component_info.json and bump its next_error_code.
 const (
 	ErrGetMeshsyncCode       = "1001"
 	ErrCreateMeshsyncCode    = "1002"
@@ -34,58 +34,122 @@ const (
 	ErrCheckHealthCode       = "1010"
 	ErrGetEndpointCode       = "1011"
 	ErrUpdateResourceCode    = "1012"
-	ErrMarshalCode           = "11049"
+	ErrMarshalCode           = "1017"
 )
 
-// ErrGetMeshsync returns an error when unable to get meshsync resource
+// ErrGetMeshsync is returned when the MeshSync custom resource cannot be fetched.
 func ErrGetMeshsync(err error) error {
-	return fmt.Errorf("%s: Unable to get meshsync resource: %w", ErrGetMeshsyncCode, err)
+	return meshkiterrors.New(ErrGetMeshsyncCode, meshkiterrors.Alert,
+		[]string{"Unable to get the MeshSync resource"},
+		[]string{err.Error()},
+		[]string{"The MeshSync custom resource was deleted, or operator RBAC denies get/list/watch on meshsyncs"},
+		[]string{"Confirm the MeshSync CR exists and that the operator's ClusterRole grants get/list/watch on meshsyncs.meshery.io"})
 }
 
+// ErrCreateMeshsync is returned when the MeshSync workload cannot be created.
 func ErrCreateMeshsync(err error) error {
-	return fmt.Errorf("%s: Unable to create meshsync controller: %w", ErrCreateMeshsyncCode, err)
+	return meshkiterrors.New(ErrCreateMeshsyncCode, meshkiterrors.Alert,
+		[]string{"Unable to create the MeshSync workload"},
+		[]string{err.Error()},
+		[]string{"The MeshSync Deployment or its owned objects could not be created"},
+		[]string{"Check the operator RBAC for deployments and inspect the events in the MeshSync namespace"})
 }
 
+// ErrDeleteMeshsync is returned when MeshSync-owned objects cannot be deleted.
 func ErrDeleteMeshsync(err error) error {
-	return fmt.Errorf("%s: Unable to delete meshsync controller: %w", ErrDeleteMeshsyncCode, err)
+	return meshkiterrors.New(ErrDeleteMeshsyncCode, meshkiterrors.Alert,
+		[]string{"Unable to delete the MeshSync workload"},
+		[]string{err.Error()},
+		[]string{"Owned MeshSync objects could not be deleted during finalization"},
+		[]string{"Inspect the MeshSync finalizers and confirm the operator RBAC grants delete on deployments"})
 }
 
+// ErrReconcileMeshsync is returned when MeshSync reconciliation fails.
 func ErrReconcileMeshsync(err error) error {
-	return fmt.Errorf("%s: Error during meshsync resource reconciliation: %w", ErrReconcileMeshsyncCode, err)
+	return meshkiterrors.New(ErrReconcileMeshsyncCode, meshkiterrors.Alert,
+		[]string{"MeshSync reconciliation failed"},
+		[]string{err.Error()},
+		[]string{"Broker configuration, workload deployment, or the health check failed for MeshSync"},
+		[]string{"Check the MeshSync status conditions and the operator logs for the failing reconcile step"})
 }
 
+// ErrGetBroker is returned when the Broker custom resource cannot be fetched.
 func ErrGetBroker(err error) error {
-	return fmt.Errorf("%s: Broker resource not found: %w", ErrGetBrokerCode, err)
+	return meshkiterrors.New(ErrGetBrokerCode, meshkiterrors.Alert,
+		[]string{"Unable to get the Broker resource"},
+		[]string{err.Error()},
+		[]string{"The Broker custom resource was deleted, or operator RBAC denies get/list/watch on brokers"},
+		[]string{"Confirm the Broker CR exists and that the operator's ClusterRole grants get/list/watch on brokers.meshery.io"})
 }
 
+// ErrCreateBroker is returned when the Broker workload cannot be created.
 func ErrCreateBroker(err error) error {
-	return fmt.Errorf("%s: Unable to create broker controller: %w", ErrCreateBrokerCode, err)
+	return meshkiterrors.New(ErrCreateBrokerCode, meshkiterrors.Alert,
+		[]string{"Unable to create the Broker workload"},
+		[]string{err.Error()},
+		[]string{"The NATS StatefulSet, Service, or ConfigMaps could not be created"},
+		[]string{"Check the operator RBAC and inspect the events on the owned objects in the broker namespace"})
 }
 
+// ErrDeleteBroker is returned when Broker-owned objects cannot be deleted.
 func ErrDeleteBroker(err error) error {
-	return fmt.Errorf("%s: Unable to delete broker controller: %w", ErrDeleteBrokerCode, err)
+	return meshkiterrors.New(ErrDeleteBrokerCode, meshkiterrors.Alert,
+		[]string{"Unable to delete the Broker workload"},
+		[]string{err.Error()},
+		[]string{"Owned broker objects could not be deleted during finalization"},
+		[]string{"Inspect the Broker finalizers and confirm the operator RBAC grants delete on statefulsets, services, and configmaps"})
 }
 
+// ErrReconcileBroker is returned when Broker reconciliation fails.
 func ErrReconcileBroker(err error) error {
-	return fmt.Errorf("%s: Error during broker resource reconciliation: %w", ErrReconcileBrokerCode, err)
+	return meshkiterrors.New(ErrReconcileBrokerCode, meshkiterrors.Alert,
+		[]string{"Broker reconciliation failed"},
+		[]string{err.Error()},
+		[]string{"The NATS StatefulSet, Service, or ConfigMaps could not be created or updated"},
+		[]string{"Check the operator RBAC and inspect the events on the owned objects in the broker namespace"})
 }
 
+// ErrReconcileCR is returned when a custom resource reconcile step fails.
 func ErrReconcileCR(err error) error {
-	return fmt.Errorf("%s: Error during custom resource reconciliation: %w", ErrReconcileCRCode, err)
+	return meshkiterrors.New(ErrReconcileCRCode, meshkiterrors.Alert,
+		[]string{"Custom resource reconciliation failed"},
+		[]string{err.Error()},
+		[]string{"A reconcile step failed for the custom resource"},
+		[]string{"Check the operator logs for the underlying cause; the controller will requeue and retry"})
 }
 
+// ErrCheckHealth is returned when a managed workload fails its health check.
 func ErrCheckHealth(err error) error {
-	return fmt.Errorf("%s: Error during health check: %w", ErrCheckHealthCode, err)
+	return meshkiterrors.New(ErrCheckHealthCode, meshkiterrors.Alert,
+		[]string{"Workload health check failed"},
+		[]string{err.Error()},
+		[]string{"The StatefulSet or Deployment has not reached its desired ReadyReplicas"},
+		[]string{"Inspect the pod status and events for the workload; the controller will requeue and retry"})
 }
 
+// ErrGetEndpoint is returned when the broker endpoint cannot be derived.
 func ErrGetEndpoint(err error) error {
-	return fmt.Errorf("%s: Unable to get endpoint: %w", ErrGetEndpointCode, err)
+	return meshkiterrors.New(ErrGetEndpointCode, meshkiterrors.Alert,
+		[]string{"Unable to derive the broker endpoint"},
+		[]string{err.Error()},
+		[]string{"The broker Service has no reachable internal or external address yet"},
+		[]string{"Verify the broker Service exists and has assigned ports and an address; LoadBalancer addresses may still be pending"})
 }
 
+// ErrUpdateResource is returned when a resource or its status cannot be updated.
 func ErrUpdateResource(err error) error {
-	return fmt.Errorf("%s: Unable to update resource: %w", ErrUpdateResourceCode, err)
+	return meshkiterrors.New(ErrUpdateResourceCode, meshkiterrors.Alert,
+		[]string{"Unable to update the resource"},
+		[]string{err.Error()},
+		[]string{"A status patch or resource update conflicted or was rejected by the API server"},
+		[]string{"Check for concurrent writers and confirm the operator RBAC grants update on the resource and its status; the controller will retry"})
 }
 
+// ErrMarshal is returned when a resource cannot be marshaled for a status patch.
 func ErrMarshal(err error) error {
-	return fmt.Errorf("%s: Error during marshaling: %w", ErrMarshalCode, err)
+	return meshkiterrors.New(ErrMarshalCode, meshkiterrors.Alert,
+		[]string{"Unable to marshal the resource"},
+		[]string{err.Error()},
+		[]string{"The custom resource could not be serialized for a status patch"},
+		[]string{"This indicates a defect in the status builder; please report it with the operator logs"})
 }

--- a/controllers/error_test.go
+++ b/controllers/error_test.go
@@ -19,192 +19,95 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	meshkiterrors "github.com/meshery/meshkit/errors"
 )
 
+// assertMeshkitError verifies a constructor returns a MeshKit structured error
+// carrying the expected code, Alert severity, and the underlying cause.
+func assertMeshkitError(t *testing.T, err error, wantCode, wantCause string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if got := meshkiterrors.GetCode(err); got != wantCode {
+		t.Errorf("expected code %q, got %q", wantCode, got)
+	}
+	if got := meshkiterrors.GetSeverity(err); got != meshkiterrors.Alert {
+		t.Errorf("expected severity Alert (%d), got %d", meshkiterrors.Severity(meshkiterrors.Alert), got)
+	}
+	if wantCause != "" && !strings.Contains(err.Error(), wantCause) {
+		t.Errorf("expected error to carry cause %q, got: %s", wantCause, err.Error())
+	}
+}
+
 func TestErrGetMeshsync(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrGetMeshsync(testErr)
-
-	expectedPrefix := "1001: Unable to get meshsync resource:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	// Test error unwrapping
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrGetMeshsync(errors.New("boom")), ErrGetMeshsyncCode, "boom")
 }
 
 func TestErrCreateMeshsync(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrCreateMeshsync(testErr)
-
-	expectedPrefix := "1002: Unable to create meshsync controller:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrCreateMeshsync(errors.New("boom")), ErrCreateMeshsyncCode, "boom")
 }
 
 func TestErrDeleteMeshsync(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrDeleteMeshsync(testErr)
-
-	expectedPrefix := "1008: Unable to delete meshsync controller:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrDeleteMeshsync(errors.New("boom")), ErrDeleteMeshsyncCode, "boom")
 }
 
 func TestErrReconcileMeshsync(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrReconcileMeshsync(testErr)
-
-	expectedPrefix := "1003: Error during meshsync resource reconciliation:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
+	assertMeshkitError(t, ErrReconcileMeshsync(errors.New("boom")), ErrReconcileMeshsyncCode, "boom")
 }
 
-// Test case for ErrGetBroker
 func TestErrGetBroker(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrGetBroker(testErr)
-
-	expectedPrefix := "1004: Broker resource not found:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrGetBroker(errors.New("boom")), ErrGetBrokerCode, "boom")
 }
 
-// Test case for ErrCreateBroker
 func TestErrCreateBroker(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrCreateBroker(testErr)
-
-	expectedPrefix := "1005: Unable to create broker controller:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrCreateBroker(errors.New("boom")), ErrCreateBrokerCode, "boom")
 }
 
-// Test case for ErrDeleteBroker
 func TestErrDeleteBroker(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrDeleteBroker(testErr)
-
-	expectedPrefix := "1009: Unable to delete broker controller:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrDeleteBroker(errors.New("boom")), ErrDeleteBrokerCode, "boom")
 }
 
-// Test case for ErrReconcileBroker
 func TestErrReconcileBroker(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrReconcileBroker(testErr)
-
-	expectedPrefix := "1006: Error during broker resource reconciliation:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrReconcileBroker(errors.New("boom")), ErrReconcileBrokerCode, "boom")
 }
 
-// Test case for ErrReconcileCR
 func TestErrReconcileCR(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrReconcileCR(testErr)
-
-	expectedPrefix := "1007: Error during custom resource reconciliation:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrReconcileCR(errors.New("boom")), ErrReconcileCRCode, "boom")
 }
 
-// Test case for ErrCheckHealth
 func TestErrCheckHealth(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrCheckHealth(testErr)
-
-	expectedPrefix := "1010: Error during health check:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrCheckHealth(errors.New("boom")), ErrCheckHealthCode, "boom")
 }
 
-// Test case for ErrGetEndpoint
 func TestErrGetEndpoint(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrGetEndpoint(testErr)
-
-	expectedPrefix := "1011: Unable to get endpoint:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrGetEndpoint(errors.New("boom")), ErrGetEndpointCode, "boom")
 }
 
-// Test case for ErrUpdateResource
 func TestErrUpdateResource(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrUpdateResource(testErr)
-
-	expectedPrefix := "1012: Unable to update resource:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
-	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
-	}
+	assertMeshkitError(t, ErrUpdateResource(errors.New("boom")), ErrUpdateResourceCode, "boom")
 }
 
-// Test case for ErrMarshal
 func TestErrMarshal(t *testing.T) {
-	testErr := errors.New("test error")
-	err := ErrMarshal(testErr)
+	assertMeshkitError(t, ErrMarshal(errors.New("boom")), ErrMarshalCode, "boom")
+}
 
-	expectedPrefix := "11049: Error during marshaling:"
-	if !strings.Contains(err.Error(), expectedPrefix) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedPrefix, err.Error())
+// TestErrorCodesUnique guards against the historical code collision between the
+// controllers registry and the pkg/* registries by asserting every code in this
+// package is distinct.
+func TestErrorCodesUnique(t *testing.T) {
+	codes := []string{
+		ErrGetMeshsyncCode, ErrCreateMeshsyncCode, ErrReconcileMeshsyncCode,
+		ErrGetBrokerCode, ErrCreateBrokerCode, ErrReconcileBrokerCode,
+		ErrReconcileCRCode, ErrDeleteMeshsyncCode, ErrDeleteBrokerCode,
+		ErrCheckHealthCode, ErrGetEndpointCode, ErrUpdateResourceCode, ErrMarshalCode,
 	}
-
-	if !errors.Is(err, testErr) {
-		t.Error("Expected error to wrap the original error")
+	seen := make(map[string]bool, len(codes))
+	for _, c := range codes {
+		if seen[c] {
+			t.Errorf("duplicate error code %q within the controllers registry", c)
+		}
+		seen[c] = true
 	}
 }

--- a/controllers/meshsync_controller.go
+++ b/controllers/meshsync_controller.go
@@ -147,8 +147,8 @@ func (r *MeshSyncReconciler) checkMeshsyncHealth(ctx context.Context, baseResour
 func (r *MeshSyncReconciler) patchMeshsyncStatus(ctx context.Context, log logr.Logger, baseResource *mesheryv1alpha1.MeshSync) (ctrl.Result, error) {
 	patch, err := utils.Marshal(baseResource)
 	if err != nil {
-		err = ErrUpdateResource(err)
-		log.Error(err, "unable to update meshsync resource")
+		err = ErrMarshal(err)
+		log.Error(err, "unable to marshal meshsync resource")
 		return ctrl.Result{}, err
 	}
 	err = r.Status().Patch(ctx, baseResource, client.RawPatch(types.MergePatchType, []byte(patch)))

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,39 +1,44 @@
 # Error handling
 
-The operator is standardizing on **MeshKit structured errors**
-(`github.com/meshery/meshkit/errors`) as its error-handling convention. The goal is
-that every error returned from a controller or package is constructed with a stable
-code and rich, user-facing metadata so that Meshery Server and the meshkit
-error-reference tooling can surface actionable guidance instead of an opaque string.
-New errors must use this form; the existing registry is mid-migration (see
-[Migration status](#migration-status) below).
+The operator uses **MeshKit structured errors**
+(`github.com/meshery/meshkit/errors`) as its error-handling convention. Every error
+returned from a controller or package is constructed with a stable code and rich,
+user-facing metadata so that Meshery Server and the meshkit error-reference tooling
+can surface actionable guidance instead of an opaque string.
 
 ## The convention
 
 Define one exported code constant per error, matching the regex `^Err[A-Z].+Code$`,
-and one constructor that wraps the underlying cause:
+and one constructor that carries the underlying cause. Error names and codes are
+unique within the whole component (not just within a Go package), so name each
+constructor distinctly - e.g. `ErrGettingBrokerResource` and
+`ErrGettingMeshsyncResource`, not two `ErrGettingResource`:
 
 ```go
-import "github.com/meshery/meshkit/errors"
+import meshkiterrors "github.com/meshery/meshkit/errors"
 
-// Codes are unique within the component. Allocate the next free code from
-// helpers/component_info.json and bump its next_error_code.
-const ErrReconcileBrokerCode = "meshery-operator-1006"
+// Codes are bare integers, unique within the component. Allocate the next free
+// code from helpers/component_info.json and bump its next_error_code.
+const ErrReconcileBrokerCode = "1006"
 
 func ErrReconcileBroker(err error) error {
-    return errors.New(
+    return meshkiterrors.New(
         ErrReconcileBrokerCode,
-        errors.Alert,                                              // Severity
-        []string{"Failed to reconcile the Broker custom resource"}, // ShortDescription
-        []string{err.Error()},                                     // LongDescription
+        meshkiterrors.Alert,                                       // Severity
+        []string{"Broker reconciliation failed"},                  // ShortDescription
+        []string{err.Error()},                                     // LongDescription (cause)
         []string{"The NATS StatefulSet, Service, or ConfigMaps could not be created or updated"}, // ProbableCause
         []string{"Check the operator RBAC and the events on the owned objects in the broker's namespace"}, // SuggestedRemediation
     )
 }
 ```
 
-`errors.NewDefault(code, ldescription...)` exists for the rare case where only a
-code and message are available, but prefer the full `errors.New` form.
+The ShortDescription, ProbableCause, and SuggestedRemediation must be string
+literals so the errorutil tool can extract them for the error reference; the dynamic
+cause (`err.Error()`) goes in the LongDescription and is not extracted.
+`meshkiterrors.NewDefault(code, ldescription...)` exists for the rare case where only
+a code and message are available, but it is deprecated - prefer the full
+`meshkiterrors.New` form.
 
 ## Rules
 
@@ -47,16 +52,25 @@ code and message are available, but prefer the full `errors.New` form.
   `log.Error`/print to stdout.
 - **Allocate codes from `helpers/component_info.json`.** Bump `next_error_code`
   when you add one; do not reuse or guess codes.
-- **Wrap, don't swallow.** Always pass the underlying `err` into the
-  LongDescription (or wrap with `%w` upstream) so the root cause is preserved.
+- **Carry, don't swallow.** Always pass the underlying `err` into the
+  LongDescription so the root cause is preserved in the message. MeshKit errors are
+  the terminal error type (they do not implement `Unwrap`), so capture the cause at
+  construction time.
 
-## Migration status
+## Tooling
 
-The error registry in `controllers/error.go` historically used `fmt.Errorf` with
-bare numeric string codes (`1001`-`1012`, plus an outlier `11049`), while
-`pkg/broker/error.go` and `pkg/meshsync/error.go` use the standard-library `errors`
-package with concatenated codes (`1013`-`1016`) that currently collide across the
-two packages. These are being migrated to the MeshKit form above and renumbered into
-the `meshery-operator-NNNN` namespace (allocated from `helpers/component_info.json`)
-as the controllers are reworked (WS-3, #785); new errors must use the MeshKit form
-from the outset.
+- `make error` runs the meshkit errorutil analyzer (read-only). It validates that
+  codes and names are unique, flags deprecated `NewDefault` usage, and regenerates
+  the `errorutil_*.json` reference files under `helpers/` (gitignored). Run it after
+  adding or changing an error.
+- `make error-util` assigns codes to any new placeholder constants and bumps
+  `next_error_code` in `helpers/component_info.json`.
+
+## Status
+
+All three error registries use the MeshKit form: `controllers/error.go` (codes
+`1001`-`1012` and `1017`), `pkg/broker/error.go` (`1013`-`1016`), and
+`pkg/meshsync/error.go` (`1018`-`1021`). The meshsync registry was renumbered and
+renamed from its original `1013`-`1016` to resolve a code-and-name collision with the
+broker registry, and the controllers' `ErrMarshal` outlier (`11049`) was renumbered
+to `1017`. `make error` reports no duplicate codes or names.

--- a/helpers/component_info.json
+++ b/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-operator",
   "type": "component",
-  "next_error_code": 1017
+  "next_error_code": 1022
 }

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -67,18 +67,18 @@ func CheckHealth(ctx context.Context, m *mesheryv1alpha1.Broker, client client.C
 	obj := &v1.StatefulSet{}
 	err := client.Get(ctx, types.NamespacedName{Name: m.Name, Namespace: m.Namespace}, obj)
 	if err != nil {
-		return ErrGettingResource(err)
+		return ErrGettingBrokerResource(err)
 	}
 
 	if obj.Status.Replicas != obj.Status.ReadyReplicas {
 		if len(obj.Status.Conditions) > 0 {
-			return ErrReplicasNotReady(obj.Status.Conditions[0].Reason)
+			return ErrBrokerReplicasNotReady(obj.Status.Conditions[0].Reason)
 		}
-		return ErrReplicasNotReady("Condition Unknown")
+		return ErrBrokerReplicasNotReady("Condition Unknown")
 	}
 
 	if len(obj.Status.Conditions) > 0 && (obj.Status.Conditions[0].Status == corev1.ConditionFalse || obj.Status.Conditions[0].Status == corev1.ConditionUnknown) {
-		return ErrConditionFalse(obj.Status.Conditions[0].Reason)
+		return ErrBrokerConditionFalse(obj.Status.Conditions[0].Reason)
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func GetEndpoint(ctx context.Context, m *mesheryv1alpha1.Broker, client client.C
 	serviceObj := &corev1.Service{}
 	err := client.Get(ctx, types.NamespacedName{Name: m.Name, Namespace: m.Namespace}, serviceObj)
 	if err != nil {
-		return ErrGettingResource(err)
+		return ErrGettingBrokerResource(err)
 	}
 
 	opts := &meshkitkube.ServiceOptions{
@@ -102,7 +102,7 @@ func GetEndpoint(ctx context.Context, m *mesheryv1alpha1.Broker, client client.C
 
 	endpoint, err := meshkitkube.GetEndpoint(ctx, opts, serviceObj)
 	if err != nil {
-		return ErrGettingEndpoint(err)
+		return ErrGettingBrokerEndpoint(err)
 	}
 
 	// Set the broker status endpoints

--- a/pkg/broker/error.go
+++ b/pkg/broker/error.go
@@ -17,28 +17,52 @@ limitations under the License.
 package broker
 
 import (
-	"errors"
+	meshkiterrors "github.com/meshery/meshkit/errors"
 )
 
+// Error codes. Names and codes are unique within the meshery-operator component;
+// allocate the next free code from helpers/component_info.json and bump its
+// next_error_code.
 const (
-	ErrGettingResourceCode  = "1013"
-	ErrReplicasNotReadyCode = "1014"
-	ErrConditionFalseCode   = "1015"
-	ErrGettingEndpointCode  = "1016"
+	ErrGettingBrokerResourceCode  = "1013"
+	ErrBrokerReplicasNotReadyCode = "1014"
+	ErrBrokerConditionFalseCode   = "1015"
+	ErrGettingBrokerEndpointCode  = "1016"
 )
 
-func ErrGettingResource(err error) error {
-	return errors.New(ErrGettingResourceCode + ":" + "Unable to get resource" + err.Error())
+// ErrGettingBrokerResource is returned when a broker-owned resource cannot be fetched.
+func ErrGettingBrokerResource(err error) error {
+	return meshkiterrors.New(ErrGettingBrokerResourceCode, meshkiterrors.Alert,
+		[]string{"Unable to get a broker-owned resource"},
+		[]string{err.Error()},
+		[]string{"The broker StatefulSet, Service, or ConfigMap lookup failed"},
+		[]string{"Check the operator RBAC and confirm the resource exists in the broker namespace"})
 }
 
-func ErrGettingEndpoint(err error) error {
-	return errors.New(ErrGettingEndpointCode + ":" + "Unable to get endpoint" + err.Error())
+// ErrGettingBrokerEndpoint is returned when the broker endpoint cannot be resolved.
+func ErrGettingBrokerEndpoint(err error) error {
+	return meshkiterrors.New(ErrGettingBrokerEndpointCode, meshkiterrors.Alert,
+		[]string{"Unable to get the broker endpoint"},
+		[]string{err.Error()},
+		[]string{"The broker Service is not yet reachable or has no assigned address"},
+		[]string{"Verify the broker Service and its ports; a pending LoadBalancer address resolves on a later reconcile"})
 }
 
-func ErrReplicasNotReady(reason string) error {
-	return errors.New(ErrReplicasNotReadyCode + ":" + "The replicas are not ready" + reason)
+// ErrBrokerReplicasNotReady is returned when the broker workload has not reached
+// its desired ready replica count.
+func ErrBrokerReplicasNotReady(reason string) error {
+	return meshkiterrors.New(ErrBrokerReplicasNotReadyCode, meshkiterrors.Alert,
+		[]string{"Broker replicas are not ready"},
+		[]string{reason},
+		[]string{"The NATS StatefulSet has not reached its desired ReadyReplicas"},
+		[]string{"Inspect the StatefulSet pod status and events; the controller will requeue and retry"})
 }
 
-func ErrConditionFalse(reason string) error {
-	return errors.New(ErrConditionFalseCode + ":" + "The condition is false" + reason)
+// ErrBrokerConditionFalse is returned when a required broker readiness condition reports false.
+func ErrBrokerConditionFalse(reason string) error {
+	return meshkiterrors.New(ErrBrokerConditionFalseCode, meshkiterrors.Alert,
+		[]string{"A broker readiness condition is false"},
+		[]string{reason},
+		[]string{"A required status condition on the broker workload reports False"},
+		[]string{"Inspect the broker status conditions for the reported reason"})
 }

--- a/pkg/broker/error_test.go
+++ b/pkg/broker/error_test.go
@@ -18,33 +18,53 @@ package broker
 
 import (
 	"errors"
+	"strings"
 	"testing"
+
+	meshkiterrors "github.com/meshery/meshkit/errors"
 )
 
-func TestErrGettingResource(t *testing.T) {
-	err := ErrGettingResource(errors.New("test"))
+func assertMeshkitError(t *testing.T, err error, wantCode, wantDetail string) {
+	t.Helper()
 	if err == nil {
-		t.Error("expected error but got nil")
+		t.Fatal("expected an error, got nil")
+	}
+	if got := meshkiterrors.GetCode(err); got != wantCode {
+		t.Errorf("expected code %q, got %q", wantCode, got)
+	}
+	if got := meshkiterrors.GetSeverity(err); got != meshkiterrors.Alert {
+		t.Errorf("expected severity Alert, got %d", got)
+	}
+	if wantDetail != "" && !strings.Contains(err.Error(), wantDetail) {
+		t.Errorf("expected error to carry detail %q, got: %s", wantDetail, err.Error())
 	}
 }
 
-func TestErrGettingEndpoint(t *testing.T) {
-	err := ErrGettingEndpoint(errors.New("test"))
-	if err == nil {
-		t.Error("expected error but got nil")
-	}
+func TestErrGettingBrokerResource(t *testing.T) {
+	assertMeshkitError(t, ErrGettingBrokerResource(errors.New("boom")), ErrGettingBrokerResourceCode, "boom")
 }
 
-func TestErrReplicasNotReady(t *testing.T) {
-	err := ErrReplicasNotReady("test")
-	if err == nil {
-		t.Error("expected error but got nil")
-	}
+func TestErrGettingBrokerEndpoint(t *testing.T) {
+	assertMeshkitError(t, ErrGettingBrokerEndpoint(errors.New("boom")), ErrGettingBrokerEndpointCode, "boom")
 }
 
-func TestErrConditionFalse(t *testing.T) {
-	err := ErrConditionFalse("test")
-	if err == nil {
-		t.Error("expected error but got nil")
+func TestErrBrokerReplicasNotReady(t *testing.T) {
+	assertMeshkitError(t, ErrBrokerReplicasNotReady("not enough replicas"), ErrBrokerReplicasNotReadyCode, "not enough replicas")
+}
+
+func TestErrBrokerConditionFalse(t *testing.T) {
+	assertMeshkitError(t, ErrBrokerConditionFalse("condition false"), ErrBrokerConditionFalseCode, "condition false")
+}
+
+// TestErrorCodesUnique guards against re-introducing the historical code
+// collision; every code in this package must be distinct.
+func TestErrorCodesUnique(t *testing.T) {
+	codes := []string{ErrGettingBrokerResourceCode, ErrBrokerReplicasNotReadyCode, ErrBrokerConditionFalseCode, ErrGettingBrokerEndpointCode}
+	seen := make(map[string]bool, len(codes))
+	for _, c := range codes {
+		if seen[c] {
+			t.Errorf("duplicate error code %q within the broker registry", c)
+		}
+		seen[c] = true
 	}
 }

--- a/pkg/meshsync/error.go
+++ b/pkg/meshsync/error.go
@@ -17,28 +17,53 @@ limitations under the License.
 package meshsync
 
 import (
-	"errors"
+	meshkiterrors "github.com/meshery/meshkit/errors"
 )
 
+// Error codes. Names and codes are unique within the meshery-operator component;
+// allocate the next free code from helpers/component_info.json and bump its
+// next_error_code. These were renumbered from 1013-1016 and renamed to resolve a
+// code-and-name collision with the pkg/broker registry.
 const (
-	ErrGettingResourceCode  = "1013"
-	ErrReplicasNotReadyCode = "1014"
-	ErrConditionFalseCode   = "1015"
-	ErrGettingEndpointCode  = "1016"
+	ErrGettingMeshsyncResourceCode  = "1018"
+	ErrMeshsyncReplicasNotReadyCode = "1019"
+	ErrMeshsyncConditionFalseCode   = "1020"
+	ErrGettingMeshsyncEndpointCode  = "1021"
 )
 
-func ErrGettingResource(err error) error {
-	return errors.New(ErrGettingResourceCode + ":" + "Unable to get resource" + err.Error())
+// ErrGettingMeshsyncResource is returned when a MeshSync-owned resource cannot be fetched.
+func ErrGettingMeshsyncResource(err error) error {
+	return meshkiterrors.New(ErrGettingMeshsyncResourceCode, meshkiterrors.Alert,
+		[]string{"Unable to get a MeshSync-owned resource"},
+		[]string{err.Error()},
+		[]string{"The MeshSync Deployment lookup failed"},
+		[]string{"Check the operator RBAC and confirm the Deployment exists in the MeshSync namespace"})
 }
 
-func ErrGettingEndpoint(err error) error {
-	return errors.New(ErrGettingEndpointCode + ":" + "Unable to get endpoint" + err.Error())
+// ErrGettingMeshsyncEndpoint is returned when the MeshSync broker endpoint cannot be resolved.
+func ErrGettingMeshsyncEndpoint(err error) error {
+	return meshkiterrors.New(ErrGettingMeshsyncEndpointCode, meshkiterrors.Alert,
+		[]string{"Unable to get the MeshSync broker endpoint"},
+		[]string{err.Error()},
+		[]string{"The broker referenced by the MeshSync spec has no resolvable endpoint"},
+		[]string{"Verify the native broker CR or the custom broker URL configured in the MeshSync spec"})
 }
 
-func ErrReplicasNotReady(reason string) error {
-	return errors.New(ErrReplicasNotReadyCode + ":" + "The replicas are not ready" + reason)
+// ErrMeshsyncReplicasNotReady is returned when the MeshSync workload has not
+// reached its desired ready replica count.
+func ErrMeshsyncReplicasNotReady(reason string) error {
+	return meshkiterrors.New(ErrMeshsyncReplicasNotReadyCode, meshkiterrors.Alert,
+		[]string{"MeshSync replicas are not ready"},
+		[]string{reason},
+		[]string{"The MeshSync Deployment has not reached its desired ReadyReplicas"},
+		[]string{"Inspect the Deployment pod status and events; the controller will requeue and retry"})
 }
 
-func ErrConditionFalse(reason string) error {
-	return errors.New(ErrConditionFalseCode + ":" + "The condition is false" + reason)
+// ErrMeshsyncConditionFalse is returned when a required MeshSync readiness condition reports false.
+func ErrMeshsyncConditionFalse(reason string) error {
+	return meshkiterrors.New(ErrMeshsyncConditionFalseCode, meshkiterrors.Alert,
+		[]string{"A MeshSync readiness condition is false"},
+		[]string{reason},
+		[]string{"A required status condition on the MeshSync workload reports False"},
+		[]string{"Inspect the MeshSync status conditions for the reported reason"})
 }

--- a/pkg/meshsync/error_test.go
+++ b/pkg/meshsync/error_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright Meshery Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshsync
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	meshkiterrors "github.com/meshery/meshkit/errors"
+)
+
+func assertMeshkitError(t *testing.T, err error, wantCode, wantDetail string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if got := meshkiterrors.GetCode(err); got != wantCode {
+		t.Errorf("expected code %q, got %q", wantCode, got)
+	}
+	if got := meshkiterrors.GetSeverity(err); got != meshkiterrors.Alert {
+		t.Errorf("expected severity Alert, got %d", got)
+	}
+	if wantDetail != "" && !strings.Contains(err.Error(), wantDetail) {
+		t.Errorf("expected error to carry detail %q, got: %s", wantDetail, err.Error())
+	}
+}
+
+func TestErrGettingMeshsyncResource(t *testing.T) {
+	assertMeshkitError(t, ErrGettingMeshsyncResource(errors.New("boom")), ErrGettingMeshsyncResourceCode, "boom")
+}
+
+func TestErrGettingMeshsyncEndpoint(t *testing.T) {
+	assertMeshkitError(t, ErrGettingMeshsyncEndpoint(errors.New("boom")), ErrGettingMeshsyncEndpointCode, "boom")
+}
+
+func TestErrMeshsyncReplicasNotReady(t *testing.T) {
+	assertMeshkitError(t, ErrMeshsyncReplicasNotReady("not enough replicas"), ErrMeshsyncReplicasNotReadyCode, "not enough replicas")
+}
+
+func TestErrMeshsyncConditionFalse(t *testing.T) {
+	assertMeshkitError(t, ErrMeshsyncConditionFalse("condition false"), ErrMeshsyncConditionFalseCode, "condition false")
+}
+
+// TestErrorCodesDistinctFromBroker documents that the meshsync registry was
+// renumbered (1018-1021) to no longer collide with the broker registry
+// (1013-1016).
+func TestErrorCodesDistinctFromBroker(t *testing.T) {
+	brokerCodes := map[string]bool{"1013": true, "1014": true, "1015": true, "1016": true}
+	for _, c := range []string{ErrGettingMeshsyncResourceCode, ErrMeshsyncReplicasNotReadyCode, ErrMeshsyncConditionFalseCode, ErrGettingMeshsyncEndpointCode} {
+		if brokerCodes[c] {
+			t.Errorf("meshsync error code %q collides with the broker registry", c)
+		}
+	}
+}

--- a/pkg/meshsync/meshsync.go
+++ b/pkg/meshsync/meshsync.go
@@ -57,18 +57,18 @@ func CheckHealth(ctx context.Context, m *mesheryv1alpha1.MeshSync, client client
 	obj := &v1.Deployment{}
 	err := client.Get(ctx, types.NamespacedName{Name: m.Name, Namespace: m.Namespace}, obj)
 	if err != nil {
-		return ErrGettingResource(err)
+		return ErrGettingMeshsyncResource(err)
 	}
 
 	if obj.Status.Replicas != obj.Status.ReadyReplicas {
 		if len(obj.Status.Conditions) > 0 {
-			return ErrReplicasNotReady(obj.Status.Conditions[0].Reason)
+			return ErrMeshsyncReplicasNotReady(obj.Status.Conditions[0].Reason)
 		}
-		return ErrReplicasNotReady("Condition Unknown")
+		return ErrMeshsyncReplicasNotReady("Condition Unknown")
 	}
 
 	if len(obj.Status.Conditions) > 0 && (obj.Status.Conditions[0].Status == corev1.ConditionFalse || obj.Status.Conditions[0].Status == corev1.ConditionUnknown) {
-		return ErrConditionFalse(obj.Status.Conditions[0].Reason)
+		return ErrMeshsyncConditionFalse(obj.Status.Conditions[0].Reason)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Adopts **MeshKit structured errors** across the operator's three error registries, the project-wide convention documented in [How to write MeshKit compatible errors](https://docs.meshery.io/project/contributing/contributing-error). This is the error-handling portion of WS-3, pulled forward on its own.

### What changed
- **Migrated** `controllers/error.go`, `pkg/broker/error.go`, and `pkg/meshsync/error.go` from `fmt.Errorf` / standard-library `errors.New` to `meshkiterrors.New(code, errors.Alert, short, long, probableCause, remediation)`. Every operator error now carries a stable code, severity, probable cause, and suggested remediation so Meshery Server and the errorutil tooling can surface actionable guidance instead of an opaque string.
- **Fixed a latent code-and-name collision (owned bug):** `pkg/broker` and `pkg/meshsync` were byte-identical copies that both declared codes `1013`-`1016` under the same constant names (`ErrGettingResourceCode`, etc.). MeshKit requires codes and names to be unique within a component. The meshsync registry is renumbered to `1018`-`1021` and its constructors renamed (`ErrGettingMeshsyncResource`, `ErrMeshsyncReplicasNotReady`, ...); the controllers' `ErrMarshal` outlier (`11049`) is renumbered to `1017`.
- **Wired tooling:** added `make error` (errorutil analyze - read-only validation + reference export) and `make error-util` (code assignment), mirroring meshery. Bumped `next_error_code` to `1022` in `helpers/component_info.json`. `make error` reports zero duplicate codes or names.
- **Tests:** updated the error tests to assert the MeshKit shape (code via `errors.GetCode`, `Alert` severity, cause preserved in the message), added the previously-missing `pkg/meshsync` error test, and added uniqueness guards.
- **Docs:** refreshed `docs/errors.md` to reflect the completed migration. The contributor-facing build guide ([meshery/meshery#20366](https://github.com/meshery/meshery/pull/20366)) documents the `make error` workflow.

### Out-of-scope fixes folded in
- **`ErrMarshal` wiring (bug fix, separate commit):** `patchBrokerStatus`/`patchMeshsyncStatus` returned `ErrUpdateResource` (code 1012, "unable to update") when `utils.Marshal` failed, though the failure is a marshaling error. They now return the purpose-built `ErrMarshal` (1017), which was previously declared but unused.

### Notes
- `ErrReconcileCR` (code 1007) remains declared-but-unused. It is pre-existing dead code, left in place here to avoid scope creep and a code-range gap; flagging it for a future cleanup decision.
- MeshKit errors are the terminal error type (no `Unwrap`), per the project convention; the underlying cause is captured into the LongDescription at construction time. Verified no code outside the error tests relied on `errors.Is`/`errors.As` unwrapping of these errors.
- No public CRD/API change; reconcile behavior is unchanged (the envtest suites pass unmodified).

### Test plan
- [x] `make test` (unit + envtest suites) - all packages pass
- [x] `make lint` - 0 issues
- [x] `make error` - no duplicate codes or names; codes contiguous `1001`-`1021`, `next_error_code` `1022`
- [x] `go build ./...` / `go vet ./...` clean

## Signed commits
- [x] Yes, I signed my commits.
