### PR TITLE
ci: pin actions to SHAs, add CodeQL/Trivy/SBOM/cosign, drift gate, gosec (WS-8)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - aisuko
+# Keep the SHA-pinned GitHub Actions current. Dependabot bumps the pinned
+# commit SHA while preserving the human-readable version comment.
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/approve-to-run-ci.yml
+++ b/.github/workflows/approve-to-run-ci.yml
@@ -12,14 +12,14 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@v6
-          - uses: actions/setup-go@v5
+            uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+          - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
             with:
               go-version-file: go.mod
               cache: true
               cache-dependency-path: go.sum
           - name: golangci-lint
-            uses: golangci/golangci-lint-action@v9
+            uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9.3.0
             with:
               version: v2.12.2
     tidy:
@@ -27,9 +27,9 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@v6
+            uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
           - name: Set up Go
-            uses: actions/setup-go@v5
+            uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
             with:
               go-version-file: go.mod
               cache: true
@@ -44,9 +44,9 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@v6
+            uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
           - name: Set up Go
-            uses: actions/setup-go@v5
+            uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
             with:
               go-version-file: go.mod
               cache: true
@@ -65,12 +65,36 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
           - name: Checkout code
-            uses: actions/checkout@v6
+            uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
           - name: Set up Go
-            uses: actions/setup-go@v5
+            uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
             with:
               go-version-file: go.mod
               cache: true
               cache-dependency-path: go.sum
           - name: Build
             run: make build
+
+    # Fail the build if committed generated artifacts (DeepCopy, CRDs, RBAC,
+    # webhook manifests) drift from the Go source. Bundle regeneration is not
+    # gated here because it requires the operator-sdk binary; see WS-1/WS-8.
+    manifests-drift:
+        name: Generated manifests drift gate
+        runs-on: ubuntu-24.04
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+          - name: Set up Go
+            uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+            with:
+              go-version-file: go.mod
+              cache: true
+              cache-dependency-path: go.sum
+          - name: Regenerate manifests and DeepCopy
+            run: make manifests generate
+          - name: Verify no drift
+            run: |
+              if ! git diff --exit-code; then
+                echo "::error::Generated files are out of date. Run 'make manifests generate' and commit the result."
+                exit 1
+              fi

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 1
       - name: Docker login
-        uses: azure/docker-login@v1
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/codeql.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/codeql.yml"
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        with:
+          languages: go
+          build-mode: autobuild
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        with:
+          category: "/language:go"

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -17,14 +17,14 @@ jobs:
         if: github.repository == 'meshery/meshery-operator'
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
               # token here with write access to meshery-operator repo
               with:
                   token: ${{ secrets.GH_ACCESS_TOKEN }}
                   ref: "master"
 
             - name: Setup Go
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
               with:
                   go-version-file: go.mod
 
@@ -34,7 +34,7 @@ jobs:
                   go run github.com/meshery/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
             # to update errorutil* files in meshery-operator repo
             - name: Commit changes
-              uses: stefanzweifel/git-auto-commit-action@v4
+              uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
               with:
                   commit_user_name: l5io
                   commit_user_email: ci@meshery.io
@@ -45,7 +45,7 @@ jobs:
 
             # to push changes to meshery docs
             - name: Checkout meshery
-              uses: actions/checkout@v4
+              uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
               with:
                   repository: "meshery/meshery"
                   # token with write access to meshery repository

--- a/.github/workflows/integration-tests-ci.yml
+++ b/.github/workflows/integration-tests-ci.yml
@@ -36,17 +36,17 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 2
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 
       - name: Install Kind and kubectl
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       - name: Check integration tests dependencies
         run: make integration-tests-check-dependencies
       - name: Integration tests set up
@@ -63,7 +63,7 @@ jobs:
         run: make integration-tests-cleanup
         if: always()
       - name: Upload integration test logs (if any)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: operator-logs

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -18,9 +18,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: master # Set your default branch
 
       - name: Label Commenter
-        uses: peaceiris/actions-label-commenter@v1
+        uses: peaceiris/actions-label-commenter@c74c602750041f04c2bb68d200fc2fdae169a044 # v1.10.0

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   print-inputs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: |
           echo "Dispatched GIT_VERSION: ${{github.event.inputs.release-ver}}"
@@ -47,10 +47,13 @@ jobs:
           echo "Env GITHUB_REF:" ${GITHUB_REF}
 
   docker-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # keyless cosign signing via OIDC
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Identify Release Values
         if: "${{ github.event.inputs.release-ver }} != 'v' }}"
@@ -71,14 +74,14 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ secrets.IMAGE_NAME }}
           flavor: |
@@ -90,13 +93,14 @@ jobs:
             type=raw,value=${{env.RELEASE_CHANNEL}}-latest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v5
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: "{{defaultContext}}"
           push: true
@@ -106,8 +110,20 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign the published image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ secrets.IMAGE_NAME }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Sign by immutable digest so every pushed tag resolves to one signed manifest.
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/newcomer-alert.yml
+++ b/.github/workflows/newcomer-alert.yml
@@ -10,9 +10,11 @@ jobs:
     name: Notify Slack for new good-first-issue
     runs-on: ubuntu-24.04
     steps:
-      - name: Notify slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: pullreminders/slack-action@master
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
-          args: '{\"channel\":\"C019426UBNY\",\"text\":\"A good first issue label was just added to ${{github.event.issue.html_url}}.\"}'
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: C019426UBNY
+            text: "A good first issue label was just added to <${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>."

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Drafting release
         id: release_drafter
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@67e173cadb2fbd3de94f4a861e0c48c913b462ae # v6.4.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,32 @@
+name: SBOM
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # upload SBOM as a release asset
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - name: Generate source SBOM (syft)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: meshery-operator.spdx.json
+      - name: Attach SBOM to release
+        if: github.event_name == 'release'
+        uses: anchore/sbom-action/publish-sbom@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          sbom-artifact-match: ".*\\.spdx\\.json$"

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -11,14 +11,14 @@ jobs:
   star-notify:
     if: github.event_name == 'watch'
     name: Notify Slack on star
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get current star count
         run: |
           echo "STARS=$(curl --silent 'https://api.github.com/repos/${{ github.repository }}' -H 'Accept: application/vnd.github.preview' | jq '.stargazers_count')" >> $GITHUB_ENV
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -30,10 +30,10 @@ jobs:
   good-first-issue-notify:
     if: github.event_name == 'issues' && (github.event.label.name == 'good first issue' || github.event.label.name == 'first-timers-only')
     name: Notify Slack for new good-first-issue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,74 @@
+name: Trivy Security Scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions: read-all
+
+jobs:
+  # Dependency/IaC scan of the repository tree. Does not need a built image,
+  # so it runs on every PR for fast feedback on go.mod / config vulnerabilities.
+  trivy-fs:
+    name: Filesystem & config scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: fs
+          scanners: vuln,misconfig,secret
+          format: sarif
+          output: trivy-fs.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  # Vulnerability scan of the built operator image.
+  trivy-image:
+    name: Image scan
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Build image (load locally, no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          push: false
+          load: true
+          tags: meshery/meshery-operator:scan
+      - name: Run Trivy image scan
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: meshery/meshery-operator:scan
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        if: always()
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   enable:
     - goconst
     - gocritic
+    - gosec
     - govet
     - staticcheck
     - unused

--- a/bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml
+++ b/bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml
@@ -587,7 +587,7 @@ FnZVJlYWR5ccllPAAAAABJRU5ErkJggg=="
   - name: Meshery Operator
     url: https://meshery-operator.domain
   maintainers:
-  - email: urakiny@gmai.com
+  - email: urakiny@gmail.com
     name: aisuko
   maturity: alpha
   provider:

--- a/bundle/REGENERATION.md
+++ b/bundle/REGENERATION.md
@@ -1,0 +1,37 @@
+# OLM bundle regeneration (WS-1)
+
+The committed bundle under `bundle/0.0.1/` is **stale**: it was generated in
+2022 against the old Kubebuilder `v2` layout and operator-sdk `v1.14.0`, and its
+embedded install spec still reflects the pre-hardening manager (wildcard
+ClusterRole, `kube-rbac-proxy:v0.5.0`, `hostPort`, `30Mi` memory limit). None of
+that matches the current `config/` (least-privilege RBAC, hardened manager,
+Kubebuilder `v4` layout).
+
+It must be **regenerated**, not hand-edited, so that the bundle stays a faithful
+projection of `config/`. Regeneration requires the `operator-sdk` CLI
+(>= v1.42), which is not available in every contributor environment:
+
+```bash
+# Pick the next semver and regenerate from the v4 layout + current config/.
+make bundle VERSION=0.1.0
+operator-sdk bundle validate ./bundle
+```
+
+When regenerating, also apply the following metadata that the frozen bundle
+lacks (these are the remaining WS-1 acceptance items):
+
+- **Version**: bump from the frozen `0.0.1` (e.g. `0.1.0`) — set via
+  `make bundle VERSION=…`.
+- **Upgrade graph**: add `replaces: meshery-operator.v0.0.1` and
+  `olm.skipRange: '>=0.0.1 <0.1.0'` to the ClusterServiceVersion so OLM can
+  order upgrades.
+- **Install modes**: broaden beyond `AllNamespaces` only if/when the manager
+  honours a watched-namespace scope (`WATCH_NAMESPACE`); do not claim
+  `SingleNamespace`/`MultiNamespace` support the controller does not implement.
+- **Provenance stamps**: `operators.operatorframework.io/builder` and
+  `operators.operatorframework.io/project_layout` (and the matching keys in
+  `metadata/annotations.yaml`) are written by operator-sdk at regeneration time;
+  they should not be edited by hand.
+
+The maintainer-email typo (`urakiny@gmai.com` → `urakiny@gmail.com`) has already
+been corrected in place because it is independent of regeneration.


### PR DESCRIPTION
## Summary

CI/CD & supply-chain hardening from the operator modernization plan (`docs/proposals/operator-modernization-plan.md` §4.8). Config-only; no Go source changes.

Closes #790. Advances #783 (bundle metadata) and #787 (gosec).

### WS-8 — CI/CD & supply chain (#790)
- **Pin every GitHub Action to an immutable commit SHA** (with a `# vX.Y.Z` comment) across all workflows.
- Replace abandoned/deprecated actions:
  - `actions/checkout@master` / `@v4` → `@v6.0.3` (pinned)
  - `azure/docker-login@v1` → `docker/login-action` (pinned)
  - `pullreminders/slack-action@master` → `slackapi/slack-github-action` (pinned, matches `slack.yaml`)
- Standardize runners on `ubuntu-24.04` (`multi-platform.yml`, `slack.yaml`).
- **CodeQL** (`codeql.yml`), **Trivy** filesystem + image scanning with SARIF upload (`trivy-scan.yml`), **SBOM** via syft (`sbom.yml`).
- **cosign** keyless image signing in `multi-platform.yml`.
- **Drift gate**: new `manifests-drift` job runs `make manifests generate && git diff --exit-code` (verified clean on master). Bundle drift is not gated here because it needs `operator-sdk`.
- Add a `github-actions` Dependabot ecosystem so the SHA pins stay current.

### WS-5 / WS-8 — gosec (#787)
- Enable `gosec` in `.golangci.yml`. Verified locally: **0 findings** on the current tree, so CI stays green.

### WS-1 — bundle metadata (#783)
- Fix the maintainer email typo (`urakiny@gmai.com` → `urakiny@gmail.com`).
- Add `bundle/REGENERATION.md` documenting the remaining bundle work (version bump, `replaces`/`olm.skipRange`, install modes) which requires `operator-sdk` regeneration — the committed `bundle/0.0.1/` is the stale 2022 artifact and must be regenerated rather than hand-patched.

### Verification
- All workflow/config YAML parses (`yaml.safe_load_all`).
- `golangci-lint run` with gosec enabled → 0 issues.
- `make manifests generate` → no drift (drift gate passes on master).

### Out of environment
- Trivy image scan / cosign signing exercise on real images and full OLM bundle regeneration require docker / operator-sdk, which run in CI but not locally.