### PR TITLE
fix(meshsync): drop the readiness probe; relax liveness (unblocks Integration tests)

### DIFF
--- a/pkg/meshsync/resources.go
+++ b/pkg/meshsync/resources.go
@@ -114,32 +114,21 @@ var (
 							corev1.ResourceMemory: MemoryLimit,
 						},
 					},
-					// NOTE: these probes exec the meshsync binary itself (`-h`),
-					// which forks+execs a fresh Go process on every probe. While
-					// meshsync performs its initial full-cluster sync it can
-					// saturate the node's CPU, so a 2s exec timeout is too tight
-					// on small/CPU-constrained nodes and the pod never reports
-					// Ready. Use a 10s timeout for headroom. (Replacing the
-					// exec probe with a lightweight check is tracked in WS-3.)
+					// MeshSync serves no HTTP health endpoint (its ping targets
+					// the broker's monitoring port), so the only probe available
+					// is exec'ing the binary — and `meshsync -h` only proves the
+					// binary can fork, nothing about sync health. During the
+					// initial full-cluster sync that fork can exceed any sane
+					// timeout on CPU-constrained nodes, marking a working pod
+					// unready forever. No Service routes to MeshSync, so a
+					// readiness probe gates nothing: it is intentionally absent.
+					// Liveness keeps a relaxed exec probe purely to restart a
+					// wedged container.
 					LivenessProbe: &corev1.Probe{
 						InitialDelaySeconds: 60,
-						PeriodSeconds:       10,
-						TimeoutSeconds:      10,
-						FailureThreshold:    4,
-						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: []string{
-									meshsyncBinary,
-									"-h",
-								},
-							},
-						},
-					},
-					ReadinessProbe: &corev1.Probe{
-						InitialDelaySeconds: 20,
-						PeriodSeconds:       10,
-						TimeoutSeconds:      10,
-						FailureThreshold:    4,
+						PeriodSeconds:       30,
+						TimeoutSeconds:      30,
+						FailureThreshold:    5,
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{
 								Command: []string{


### PR DESCRIPTION
## Problem

The **Integration tests** workflow has been red on master: the MeshSync Deployment never reaches `Available` on the 2-vCPU CI runner, and the e2e times out waiting for it.

Root cause: both probes `exec` the meshsync binary itself (`meshery-meshsync -h`), forking a fresh Go process on every check. During meshsync's initial full-cluster sync the node is CPU-saturated, the fork routinely exceeds the 10s probe timeout, four consecutive failures mark the pod unready, and it never converges.

## Fix

- **Readiness probe: removed.** No Service routes to MeshSync, so readiness gates nothing — and `-h` only proves the binary can fork, nothing about sync health. MeshSync exposes no HTTP health endpoint of its own (its `pingEndpoint` targets the *broker's* `:8222/connz` monitoring port), so there is no meaningful readiness signal to probe.
- **Liveness probe: relaxed** to 30s period/timeout with failureThreshold 5. It stays only to restart a genuinely wedged container, and can no longer kill a working pod that is merely busy.

## Validation

- `make test` green (unit + envtest); golangci-lint clean.
- The Integration tests job on this PR exercises the change directly — the meshsync availability wait is the step that previously failed.

Relates to #783 (WS-3/WS-7); this is the "real fix" deferred from #796, which removed the redundant chart-testing cluster but left the probe untouched.