### PR TITLE
fix(config): key the kustomize image transformer on the real image name; stale docs; Trivy policy ignores

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Justified exclusions for Trivy's Kubernetes misconfiguration checks against
+# pkg/broker/manifests/nats.gen.yaml (helm-rendered, vendored NATS manifests
+# that the operator embeds and applies itself).
+#
+# KSV-0110 (workloads in the default namespace): the rendered manifests carry
+# no metadata.namespace on purpose — the operator sets the namespace of every
+# object to the Broker CR's namespace at apply time (pkg/broker/broker.go
+# GetObjects -> SetNamespace).
+AVD-KSV-0110
+# KSV-0125 (untrusted registry): the images are the official upstream
+# docker.io/nats and docker.io/natsio artifacts pinned by tag through the
+# vendored chart; the project has no private registry mirror to point at.
+AVD-KSV-0125

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image meshery/meshery-operator=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
@@ -256,7 +256,7 @@ golangci-lint: $(LOCALBIN) ## Download golangci-lint locally if necessary.
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/manager && $(KUSTOMIZE) edit set image meshery/meshery-operator=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
 

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,7 +1,6 @@
-# The following manifests contain a self-signed issuer CR and a certificate CR.
-# More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
+# A self-signed Issuer and the serving Certificate for the operator's webhook.
+# Targets the cert-manager.io/v1 API (cert-manager >= 1.0); docs at
+# https://cert-manager.io/docs/
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,10 +3,9 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: meshery
+# The transformer entry must be keyed on the image name exactly as written in
+# manager.yaml, or `kustomize edit set image` rewrites nothing.
 images:
-- name: controller
+- name: meshery/meshery-operator
   newName: meshery/meshery-operator
-  newTag: stable-latest
-- name: meshery-operator
-  newName: meshery-operator
   newTag: stable-latest

--- a/integration-tests/main.sh
+++ b/integration-tests/main.sh
@@ -485,8 +485,24 @@ debug_output() {
   kubectl get replicaset -n "$OPERATOR_NAMESPACE" || true
   echo "=== Pod describe ==="
   kubectl describe pods -n "$OPERATOR_NAMESPACE" || true
-  echo "=== Pod logs ==="
+  echo "=== Operator logs ==="
   kubectl logs deployment/meshery-operator -n "$OPERATOR_NAMESPACE" --tail=100 || true
+
+  # Workload container logs, including the previous instance for anything
+  # crash-looping: a CrashLoopBackOff without its container's stderr is
+  # undebuggable from CI artifacts alone.
+  for c in nats reloader; do
+    echo "=== Broker container '$c' logs (current) ==="
+    kubectl logs meshery-nats-0 -c "$c" -n "$OPERATOR_NAMESPACE" --tail=50 2>&1 || true
+    echo "=== Broker container '$c' logs (previous instance) ==="
+    kubectl logs meshery-nats-0 -c "$c" -n "$OPERATOR_NAMESPACE" --previous --tail=50 2>&1 || true
+  done
+  echo "=== MeshSync logs (current) ==="
+  kubectl logs deployment/meshery-meshsync -n "$OPERATOR_NAMESPACE" --tail=50 2>&1 || true
+  echo "=== MeshSync logs (previous instance) ==="
+  kubectl logs deployment/meshery-meshsync -n "$OPERATOR_NAMESPACE" --previous --tail=50 2>&1 || true
+  echo "=== Warning events (most recent last) ==="
+  kubectl get events -n "$OPERATOR_NAMESPACE" --field-selector type=Warning --sort-by=.lastTimestamp 2>&1 | tail -20 || true
 }
 
 print_help() {


### PR DESCRIPTION
Follow-ups from Copilot's review of #798 (merged before these could land on its branch):

- **`config/manager/kustomization.yaml` transformers never matched.** The entries were named `controller` and `meshery-operator`, but manager.yaml uses `meshery/meshery-operator` — so `kustomize edit set image` (invoked by `make deploy` and `make bundle`) rewrote nothing. One correctly keyed entry now, and both Makefile call sites target it. Verified: `kustomize edit set image meshery/meshery-operator=…:test-tag` now changes the rendered Deployment image (it previously did not). The e2e was unaffected only because `main.sh` adds its own correctly keyed entry at runtime.
- **`config/certmanager/certificate.yaml`** header claimed "Targets CertManager 0.11" above `cert-manager.io/v1` manifests.
- **`.trivyignore`** documents the two accepted misconfiguration findings on the vendored NATS manifests (code-scanning alerts on #798): KSV-0110 — the rendered manifests intentionally carry no `metadata.namespace`, the operator sets the Broker CR's namespace at apply time; KSV-0125 — official upstream docker.io images, no private mirror to prefer.

Also addressed from that review without code changes here: the container-by-index concern was already fixed in #800 (`overlayBrokerSpec` selects the NATS container by name), and LB-only fields not being "cleared" is handled by SSA semantics — fields previously owned by the operator's field manager are pruned when no longer applied, so switching away from LoadBalancer removes class/sourceRanges in the same apply.