### PR TITLE
ci(release): restore immutable-release tolerance (v1.0.1 published immutable; sync aborted)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,3 +24,36 @@ jobs:
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_NOTES_PAT }}
+
+      # This repo publishes immutable releases: assets cannot be added after
+      # publish (the release-event upload in sbom.yml hit exactly this on
+      # v1.0.0). Attach the CRD bundles to the DRAFT on every master push
+      # instead, so a published release is born with current assets.
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+      - name: Render CRD bundles
+        run: make crds
+      - name: Refresh CRD bundle assets on the draft
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_NOTES_PAT }}
+          RELEASE_ID: ${{ steps.release_drafter.outputs.id }}
+          UPLOAD_URL: ${{ steps.release_drafter.outputs.upload_url }}
+        run: |
+          for name in crds.yaml crds-webhook-conversion.yaml; do
+            # Drop a stale same-name asset from a previous draft refresh.
+            asset_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
+              --jq ".[] | select(.name == \"${name}\") | .id" || true)
+            if [ -n "$asset_id" ]; then
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+            fi
+            curl -sSf -X POST \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Content-Type: application/x-yaml" \
+              --data-binary "@dist/${name}" \
+              "${UPLOAD_URL%\{*}?name=${name}" >/dev/null
+            echo "attached ${name} to draft release ${RELEASE_ID}"
+          done

--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -50,12 +50,18 @@ jobs:
       - name: Render CRD bundles
         run: make crds
 
-      - name: Attach CRD bundles to the release
+      - name: Attach CRD bundles to the release (best-effort)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ steps.ver.outputs.tag }}" \
-            dist/crds.yaml dist/crds-webhook-conversion.yaml --clobber
+          # This repo publishes immutable releases, so post-publish uploads 422.
+          # The canonical asset path is release-drafter.yml, which attaches the
+          # bundles to the draft before publish; this step only backfills
+          # releases that are still mutable and must not block the sync below.
+          if ! gh release upload "${{ steps.ver.outputs.tag }}" \
+              dist/crds.yaml dist/crds-webhook-conversion.yaml --clobber; then
+            echo "::warning::could not attach CRD bundles (immutable release). Drafts get assets via release-drafter.yml."
+          fi
 
       - name: Checkout meshery/meshery
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,13 +20,20 @@ running deployments, and the invariants that keep the pipeline honest.
 | `sbom.yml` | Attaches an SPDX SBOM to the release. |
 | `sync-downstream.yml` | Steps 1–3 below. |
 
+The CRD bundle assets (`crds.yaml`, `crds-webhook-conversion.yaml`) are
+attached to the **draft** release by `release-drafter.yml` on every master
+push — releases here can publish **immutable** (v1.0.0 and v1.0.1 both did),
+and immutable releases reject asset uploads after publish, so the draft is
+the only reliable attach point.
+
 `sync-downstream.yml` (also runnable via `workflow_dispatch` with
 `release-ver` to re-sync an existing tag):
 
-1. **Release assets** — renders `make crds` and uploads `crds.yaml` (plain,
-   conversion strategy `None`) and `crds-webhook-conversion.yaml` (kustomize
-   rendering with webhook conversion + cert-manager CA injection) to the
-   release.
+1. **Release assets (best-effort backfill)** — renders `make crds` and
+   attempts to upload both bundles to the release; on an immutable release
+   this warns and continues (the canonical asset path is the draft attach
+   above — this step only backfills still-mutable releases and must never
+   block the sync below).
 2. **Downstream sync** — checks out `meshery/meshery` and runs
    `hack/sync-downstream.sh`, which updates the `meshery-operator` chart's
    `crds/crds.yaml` + `files/crds.yaml`, stamps the chart's
@@ -99,10 +106,12 @@ operator image under the server-stamped stream.
 - **CRD updates flow through the chart's update Job**, not Helm's `crds/`
   directory (which Helm applies only on first install). Disabling the
   webhook must reset conversion to `None` explicitly (the Job does this).
-- **Immutable releases**: the repo setting is now off, but immutability is
-  stamped per-release at publish time — `v1.0.0` was published while the
-  setting was on and remains permanently sealed (no assets can ever be
-  attached to it). Releases published since accept assets normally.
+- **Immutable releases**: releases in this repo publish immutable (verified
+  empirically on both `v1.0.0` and `v1.0.1`, the latter after the setting was
+  believed disabled — treat immutability as the operative assumption).
+  Sealed releases reject asset uploads forever, so assets must land on the
+  draft (`release-drafter.yml`), and any post-publish upload must be
+  best-effort.
 - **Storage-version migration debt**: clusters upgraded from `v1alpha1`
   storage keep `status.storedVersions: [v1alpha1, v1alpha2]`. Until a
   migration (rewrite stored objects, prune `storedVersions`) runs, `v1alpha1`


### PR DESCRIPTION
v1.0.1 (published 2026-07-02T18:19Z) came out with `isImmutable: true` — immutability is still in effect — and the plain post-publish asset upload 422'd, hard-failing the sync job before the meshery/meshery sync and the chart-publish dispatch could run (run 28612192888).

Restores the two protections removed in fbeef15:
1. **Draft-time asset attach** in `release-drafter.yml` — drafts are always mutable, so releases are born with current `crds.yaml`/`crds-webhook-conversion.yaml` regardless of the setting.
2. **Best-effort post-publish upload** in `sync-downstream.yml` — an upload 422 warns instead of aborting the downstream sync + dispatch.

`docs/release-process.md` updated to record immutability as the operative assumption (development.md untouched — it already just points at release-process.md).

After merge: `sync-downstream` will be re-dispatched with `release-ver: v1.0.1` to complete the aborted sync — the upload will warn (v1.0.1 is sealed like v1.0.0) and the sync + chart-publish dispatch will proceed. Robust under either state of the setting: if immutability is ever truly disabled, the draft attach still works and the fail-soft path never triggers.