### PR TITLE
ci(release): publish operator-versioned charts to OCI (index version-space collision)

### DIFF
--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -1,14 +1,15 @@
 # Propagates release artifacts downstream on every published release:
-#   1. Renders the CRD bundles (make crds) and attaches them to the GitHub
-#      release, so `kubectl apply -f` users have a per-release artifact.
+#   1. Renders the CRD bundles (make crds) and best-effort attaches them to
+#      the GitHub release (the canonical asset path is the draft attach in
+#      release-drafter.yml — releases here publish immutable).
 #   2. Syncs the CRDs + chart versions into meshery/meshery's
 #      install/kubernetes/helm charts via hack/sync-downstream.sh, pushed
 #      directly as l5io (same convention as error-ref-publisher.yaml), with
 #      a PR fallback when master is not fast-forwardable.
-#   3. Fires a repository_dispatch (meshery-operator-released) so
-#      meshery/meshery publishes the version-matched meshery-operator chart
-#      to meshery.io/charts (.github/workflows/release-operator-chart.yml
-#      over there guards that its chart appVersion matches before publishing).
+#   3. Publishes the operator-versioned chart to oci://ghcr.io/meshery/charts.
+#      (NOT the shared meshery.io/charts index: helm's semver equates its
+#      historical server-stamped versions with operator versions and drops
+#      colliding entries on index merge.)
 name: Sync release artifacts downstream
 on:
   release:
@@ -21,6 +22,7 @@ on:
 
 permissions:
   contents: write # gh release upload
+  packages: write # helm push to ghcr.io/meshery/charts
 
 jobs:
   sync:
@@ -99,16 +101,29 @@ jobs:
             git push -f origin "$BRANCH"
             gh pr create --repo meshery/meshery --base master --head "$BRANCH" \
               --title "Sync operator CRDs + chart from meshery-operator v${VERSION}" \
-              --body "Automated sync from meshery/meshery-operator release v${VERSION} (sync-downstream workflow). Merge, then run the release-operator-chart workflow with release-ver=${VERSION} to publish the chart." \
+              --body "Automated sync from meshery/meshery-operator release v${VERSION} (sync-downstream workflow). The operator-versioned chart was published to oci://ghcr.io/meshery/charts regardless of this PR." \
               || true
             echo "pushed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Dispatch chart publish
-        if: steps.push.outputs.pushed == 'true'
+      # Operator-versioned charts go to an OCI registry, NOT the shared
+      # meshery.io/charts index: helm's semver treats the index's historical
+      # server-stamped versions (v1.0.1, v1.0.50, ...) and operator versions
+      # (1.0.1, ...) as the same version space, so `helm repo index --merge`
+      # silently drops colliding entries (verified with operator 1.0.1 vs the
+      # historical server v1.0.1). OCI tags have no such collision — and the
+      # server-stamped publish path in meshery/meshery is untouched.
+      - name: Publish operator-versioned chart (OCI)
         env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh api repos/meshery/meshery/dispatches \
-            -f event_type=meshery-operator-released \
-            -F 'client_payload[version]=${{ steps.ver.outputs.version }}'
+          STAGE=$(mktemp -d)
+          helm package meshery/install/kubernetes/helm/meshery-operator \
+            --version "$VERSION" --app-version "$VERSION" -d "$STAGE"
+          echo "$GH_TOKEN" | helm registry login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          if helm push "$STAGE/meshery-operator-$VERSION.tgz" oci://ghcr.io/meshery/charts; then
+            echo "published oci://ghcr.io/meshery/charts/meshery-operator:$VERSION"
+          else
+            echo "::warning::OCI chart push failed (org package permissions?). The sync itself succeeded; publish manually with: helm push meshery-operator-$VERSION.tgz oci://ghcr.io/meshery/charts"
+          fi

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -43,29 +43,30 @@ the only reliable attach point.
    committed as `l5io <ci@meshery.io>` with `--signoff` and pushed to master
    (same convention as `error-ref-publisher.yaml`). If the push is rejected
    (e.g. branch protection), it opens an automated PR instead.
-3. **Chart publish dispatch** — fires
-   `repository_dispatch: meshery-operator-released` at `meshery/meshery`,
-   whose `release-operator-chart.yml` publishes **only** the
-   `meshery-operator` chart to https://meshery.io/charts at the operator's
-   version. That workflow refuses to publish unless master's chart
-   `appVersion` equals the dispatched version, so a publish can never precede
-   its sync commit. The dispatch is skipped when the PR fallback was taken —
-   after merging the sync PR, run `Release Meshery Operator Chart` manually
-   with `release-ver: <version>`.
+3. **Operator-versioned chart publish (OCI)** — packages the just-synced
+   chart at the operator's version and pushes it to
+   `oci://ghcr.io/meshery/charts/meshery-operator`. Consumers:
+   `helm install meshery-operator oci://ghcr.io/meshery/charts/meshery-operator --version <version>`.
+   The push is best-effort (a registry-permission failure warns without
+   failing the sync).
 
-## Two chart version streams on meshery.io/charts
+## Two chart version streams — two channels
 
-- **Server-stamped** (pre-existing): `meshery/meshery`'s
+- **Server-stamped, on meshery.io/charts** (pre-existing): `meshery/meshery`'s
   `helm-chart-releaser.yml` republishes every chart under
   `install/kubernetes/helm/` at each **Meshery Server** release, stamping
-  `chart_version`/`app_version` with the *server* tag. Meshery Server's
-  meshkit deployment path (`ApplyHelmChart{Chart: "meshery-operator",
-  Version: <server release>}`) looks up exactly these.
-- **Operator-versioned** (added by this pipeline): `release-operator-chart.yml`
-  publishes the operator chart at the operator's own version. These are
-  additive index entries for standalone `helm install` consumers and
-  version-pinned deployments. **Never remove the server-stamped path** —
-  meshkit's lookup depends on it.
+  `chart_version`/`app_version` with the *server* tag (v-prefixed). Meshery
+  Server's meshkit deployment path (`ApplyHelmChart{Chart: "meshery-operator",
+  Version: <server release>}`) looks up exactly these. **Never remove this
+  path** — meshkit's lookup depends on it.
+- **Operator-versioned, on ghcr.io** (this pipeline): pushed as OCI artifacts
+  for standalone `helm install` consumers and version-pinned deployments.
+  These deliberately do NOT go into the shared meshery.io/charts index:
+  helm's semver treats the index's historical server-stamped versions
+  (`v1.0.1`, `v1.0.50`, …) and operator versions (`1.0.1`, …) as the same
+  version space, and `helm repo index --merge` silently drops colliding
+  entries — verified empirically when operator `1.0.1` collided with the
+  historical server-stamped `v1.0.1`.
 
 Because the server-stamped publish rewrites `appVersion` with the server tag,
 the chart's manager image tag is pinned **explicitly** in `values.yaml`
@@ -122,9 +123,8 @@ operator image under the server-stamped stream.
 1. Merge everything intended for the release; CI green on master.
 2. Publish the release draft (creates the tag).
 3. Watch the three release workflows; confirm the l5io sync commit landed on
-   `meshery/meshery` master (or merge the fallback PR + dispatch the chart
-   publish manually).
-4. Spot-check https://meshery.io/charts index for the new operator-versioned
-   chart entry.
+   `meshery/meshery` master (or merge the fallback PR).
+4. Spot-check the OCI chart:
+   `helm pull oci://ghcr.io/meshery/charts/meshery-operator --version <version>`.
 5. If the typed client changed, follow up with the `go.mod` bump in
    `meshery/meshery`.


### PR DESCRIPTION
The v1.0.1 release run exposed a collision the shared-index design couldn't survive: helm's semver equates the index's historical **server-stamped** versions (`v1.0.1`, …) with **operator** versions (`1.0.1`, …), so `helm repo index --merge` silently dropped the operator entry (verified: `helm pull --version 1.0.1` resolves to the historical server-stamped `v1.0.1` artifact; the new tgz sits orphaned on gh-pages, unreferenced). Every operator `1.0.x` collides with a past or future Meshery Server release in that index.

Fix: operator-versioned charts publish to **`oci://ghcr.io/meshery/charts/meshery-operator`** — a collision-free channel (and the modern standard; Crossplane/Istio likewise keep app-versioned charts out of shared foreign indexes). Packaged from the just-synced meshery/meshery checkout; `packages: write` added; push is best-effort with a loud warning if org registry permissions deny it. The server-stamped meshery.io/charts path (which meshkit's lookup depends on) is untouched. Companion meshery/meshery PR removes the now-obsolete `release-operator-chart.yml` dispatch receiver.

docs/release-process.md updated (channels, checklist).