### PR TITLE
chore(config): migrate config/crd kustomization off deprecated patchesStrategicMerge

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,15 +6,17 @@ resources:
 - bases/meshery.io_brokers.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+# Each patch is a strategic-merge patch keyed on the CRD's own apiVersion/kind/name
+# (kustomize v5 matches target-less `patches` entries by the patch file's metadata).
+patches:
 # [WEBHOOK] Enable the conversion webhook for each CRD (v1alpha1 <-> v1alpha2).
-- patches/webhook_in_meshsyncs.yaml
-- patches/webhook_in_brokers.yaml
+- path: patches/webhook_in_meshsyncs.yaml
+- path: patches/webhook_in_brokers.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] Enable cert-manager CA injection into each CRD's conversion config.
-- patches/cainjection_in_meshsyncs.yaml
-- patches/cainjection_in_brokers.yaml
+- path: patches/cainjection_in_meshsyncs.yaml
+- path: patches/cainjection_in_brokers.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.


### PR DESCRIPTION
## Summary

`config/crd/kustomization.yaml` still used kustomize's deprecated `patchesStrategicMerge:` field, so **every** `kustomize build config/crd` and `config/default` printed:

```
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead.
```

That warning fired on every `make crds`, `make install`, `make deploy`, `make bundle`, and `make operator-manifest` (which renders `config/manifests/default.yaml`).

This migrates the four webhook/cainjection patches to the modern kustomize v5 `patches:` form (`- path: <file>`), preserving the `+kubebuilder:scaffold:*` markers and the `configurations: [kustomizeconfig.yaml]` block.

Each patch file already carries `apiVersion`/`kind`/`metadata.name`, so kustomize v5 matches these target-less `patches` entries by the patch's own metadata and applies them as strategic-merge patches - **behaviorally identical** to the deprecated field.

## Byte-neutrality verification

| Check | Result |
|---|---|
| `kustomize build config/crd` (before vs after) | **identical** output; warning gone |
| `kustomize build config/default` (before vs after) | **identical** output; warning gone |
| `make manifests generate operator-manifest crds` then `git diff` | only `config/crd/kustomization.yaml` changed - CRD bases, RBAC, `config/manifests/default.yaml`, and `dist/` bundles all reproduced unchanged |

So the `manifests-drift` gate stays green and no downstream artifact moves.

## Note

> **Stacked on #837.** Base is `fix/stale-operator-manifest-and-arch-docs` because the verification uses the `make operator-manifest` target introduced there. Retarget to `master` once #837 merges.
