### PR TITLE
chore(config): migrate config/scorecard kustomization off deprecated patchesJson6902

### DIFF
--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+# JSON 6902 patches need an explicit target: unlike strategic-merge patches, the
+# patch body carries no apiVersion/kind/name for kustomize to match on.
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io


### PR DESCRIPTION
## Summary

`config/scorecard/kustomization.yaml` still used kustomize's deprecated `patchesJson6902:` field, so every `kustomize build config/manifests` (the `make bundle` input) printed:

```
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead.
```

This renames the field to the modern kustomize v5 `patches:` key. The two entries already carry `path` + `target`, which is exactly the shape `patches` expects for JSON 6902 patches - unlike strategic-merge patches, the patch body carries no `apiVersion`/`kind`/`name`, so an explicit `target` is required (kept verbatim). The `# +kubebuilder:scaffold:patchesJson6902` marker is preserved.

Sibling of the `config/crd` `patchesStrategicMerge` migration in #838. `config/scorecard` feeds only `config/manifests` (the OLM bundle), **not** `config/default`, so `config/manifests/default.yaml` and the operator install manifest are untouched.

## Byte-neutrality verification

| Check | Result |
|---|---|
| `kustomize build config/manifests` (before vs after) | **identical** output; `patchesJson6902` warning gone |
| `kustomize build config/default` (before vs after) | **identical** (scorecard is not in this graph) |
| `make manifests generate` then `git diff` | only `config/scorecard/kustomization.yaml` changed |

operator-sdk was not on PATH, so `make bundle` was not run - but `operator-sdk generate bundle` consumes the `kustomize build config/manifests` output, which is byte-identical, so the generated bundle is unchanged.

## Note

The `config/manifests/kustomization.yaml` file has a *commented-out* `patchesJson6902` block; that was intentionally left alone (it is inert). After this and #838 merge, `kustomize build config/manifests` renders warning-free.
