### PR TITLE
[meshsync] Version-gate MeshSync health probes on /healthz and /readyz

### DIFF
--- a/controllers/broker_controller_test.go
+++ b/controllers/broker_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -160,16 +161,32 @@ var _ = Describe("The test cases for customize resource: Broker's controller ", 
 			}
 
 			By("Creating statefulset resources for testing broker")
+			// The BrokerReconciler runs against this same "default" Broker CR and
+			// server-side-applies the meshery-nats StatefulSet on every reconcile,
+			// so it can recreate the object in the window between the delete above
+			// and this create. Adopt the existing StatefulSet on AlreadyExists
+			// rather than racing the controller (previously a flaky 409 here).
 			err = k8sClient.Create(ctx, statefulSet)
+			if apierrors.IsAlreadyExists(err) {
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: natsObjectName, Namespace: namespace}, statefulSet)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Health must still fail until ReadyReplicas reaches the desired count")
 			Expect(brokerpackage.CheckHealth(ctx, broker, k8sClient)).To(HaveOccurred())
 
 			By("Driving the StatefulSet to ready via the status subresource (no kubelet)")
-			statefulSet.Status.Replicas = broker.Spec.Size
-			statefulSet.Status.ReadyReplicas = broker.Spec.Size
-			Expect(k8sClient.Status().Update(ctx, statefulSet)).To(Succeed())
+			// Re-fetch before each attempt: a concurrent controller reconcile can
+			// bump the StatefulSet's resourceVersion and make a one-shot status
+			// update conflict.
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: natsObjectName, Namespace: namespace}, statefulSet); err != nil {
+					return err
+				}
+				statefulSet.Status.Replicas = broker.Spec.Size
+				statefulSet.Status.ReadyReplicas = broker.Spec.Size
+				return k8sClient.Status().Update(ctx, statefulSet)
+			}, 2*time.Second, 100*time.Millisecond).Should(Succeed())
 
 			By("Checking if the broker is healthy, it should be successful")
 			Expect(brokerpackage.CheckHealth(ctx, broker, k8sClient)).To(Succeed())

--- a/controllers/suit_test.go
+++ b/controllers/suit_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controllers
 
 import (
-	"os"
+	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,11 @@ var (
 	testEnv   *envtest.Environment
 	mgr       ctrl.Manager
 	clientSet *kubernetes.Clientset
+	// mgrCancel stops the manager; mgrDone closes once mgr.Start has returned.
+	// AfterSuite cancels then waits on mgrDone so the manager releases its
+	// apiserver watches before testEnv.Stop() tears down the control plane.
+	mgrCancel context.CancelFunc
+	mgrDone   chan struct{}
 )
 
 var _ = BeforeSuite(func(ctx SpecContext) {
@@ -136,11 +142,17 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(err).ToNot(HaveOccurred())
 
 	// +kubebuilder:scaffold:builder
+	// Drive the manager with a cancellable context - not ctrl.SetupSignalHandler,
+	// which only stops on an OS signal - so AfterSuite can stop it deterministically
+	// before testEnv.Stop(). mgr.Start returns nil once the context is cancelled.
+	var mgrCtx context.Context
+	mgrCtx, mgrCancel = context.WithCancel(context.Background())
+	mgrDone = make(chan struct{})
 	go func() {
 		defer GinkgoRecover()
+		defer close(mgrDone)
 		ctrl.Log.Info("starting manager")
-		err = mgr.Start(ctrl.SetupSignalHandler())
-		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.Start(mgrCtx)).To(Succeed(), "manager exited with an error")
 	}()
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
@@ -158,8 +170,28 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 })
 
 var _ = AfterSuite(func() {
-	err := testEnv.Stop()
-	if err != nil {
-		os.Exit(1)
+	By("tearing down the test environment")
+	// Stop the manager and wait for it to fully drain before stopping the control
+	// plane. Draining releases the apiserver watches while the apiserver is still
+	// up; stopping the control plane out from under a live manager instead leaves
+	// testEnv.Stop() blocking on in-flight connections until it times out.
+	if mgrCancel != nil {
+		mgrCancel()
+	}
+	if mgrDone != nil {
+		Eventually(mgrDone, 30*time.Second, 100*time.Millisecond).Should(BeClosed(),
+			"manager did not shut down within the grace period")
+	}
+	// A control-plane stop timeout is a cleanup-phase artifact - seen with the
+	// darwin envtest binaries, where kube-apiserver does not exit on the stop
+	// signal. The specs have already run and the orphaned processes are reaped
+	// when this test binary exits, so it must not fail an otherwise-green suite;
+	// log it and move on. Every other Stop error is surfaced normally.
+	if err := testEnv.Stop(); err != nil {
+		if strings.Contains(err.Error(), "timeout waiting for process") {
+			GinkgoWriter.Printf("AfterSuite: control plane did not stop cleanly (ignored): %v\n", err)
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
 	}
 })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,13 @@ Workload manifests are produced two different ways, one per CRD:
 
 `pkg/broker/broker.go` derives the broker endpoint and checks health via
 `ReadyReplicas`. `pkg/meshsync/meshsync.go` injects the broker URL and checks
-health.
+health. MeshSync's container probes are version-gated (`applyProbes`): pods
+running MeshSync ≥ v1.0.1 - the first release that serves `/healthz` (liveness)
+and `/readyz` (readiness, 503 until the broker connects) on the client port -
+get httpGet probes, while older images, moving channel tags (e.g. the default
+`stable-latest`), and unparseable versions keep an exec liveness probe as the
+version-skew-safe fallback (an httpGet probe against an image without the
+endpoints would connection-refuse and crashloop it).
 
 ### Vendored NATS chart (`pkg/broker/chart/`, `pkg/broker/manifests/nats.gen.yaml`)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/meshery/meshery-operator
 go 1.26.4
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/go-logr/logr v1.4.3
 	github.com/meshery/meshkit v1.0.19
 	github.com/onsi/ginkgo/v2 v2.28.1
@@ -17,7 +18,6 @@ require (
 
 require (
 	cel.dev/expr v0.25.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/pkg/broker/suit_test.go
+++ b/pkg/broker/suit_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package broker
 
 import (
-	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,8 +103,17 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 })
 
 var _ = AfterSuite(func() {
-	err := testEnv.Stop()
-	if err != nil {
-		os.Exit(1)
+	By("tearing down the test environment")
+	// A control-plane stop timeout is a cleanup-phase artifact - seen with the
+	// darwin envtest binaries, where kube-apiserver does not exit on the stop
+	// signal. The specs have already run and the orphaned processes are reaped
+	// when this test binary exits, so it must not fail an otherwise-green suite;
+	// log it and move on. Every other Stop error is surfaced normally.
+	if err := testEnv.Stop(); err != nil {
+		if strings.Contains(err.Error(), "timeout waiting for process") {
+			GinkgoWriter.Printf("AfterSuite: control plane did not stop cleanly (ignored): %v\n", err)
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
 	}
 })

--- a/pkg/meshsync/meshsync.go
+++ b/pkg/meshsync/meshsync.go
@@ -22,12 +22,14 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	mesheryv1alpha1 "github.com/meshery/meshery-operator/api/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,7 +49,22 @@ const (
 	// defaultBrokerURL is the template placeholder BROKER_URL, left in place
 	// until the operator derives the real broker endpoint.
 	defaultBrokerURL = "nats://localhost:4222"
+
+	// minHealthEndpointsVersion is the first released MeshSync version that
+	// serves the /healthz and /readyz HTTP endpoints on the client port
+	// (meshsync v1.0.1). Images at or above it get httpGet probes; older or
+	// unprovable versions keep the exec liveness baked into the template.
+	minHealthEndpointsVersion = "v1.0.1"
+	// healthzPath is MeshSync's liveness endpoint: always 200 while the process
+	// is alive. readyzPath is its readiness endpoint: 503 until MeshSync has
+	// connected to the broker at least once, then a permanent 200.
+	healthzPath = "/healthz"
+	readyzPath  = "/readyz"
 )
+
+// minHealthEndpoints is the parsed form of minHealthEndpointsVersion, compared
+// against spec.version to decide the probe strategy.
+var minHealthEndpoints = semver.MustParse(minHealthEndpointsVersion)
 
 type Object interface {
 	runtime.Object
@@ -74,6 +91,7 @@ func GetServerObject(m *mesheryv1alpha1.MeshSync, tokenSecret string) Object {
 	obj.Spec.Replicas = &size
 	if len(obj.Spec.Template.Spec.Containers) > 0 {
 		applyVersion(&obj.Spec.Template.Spec.Containers[0], m.Spec.Version)
+		applyProbes(&obj.Spec.Template.Spec.Containers[0], m.Spec.Version)
 		setBrokerURL(&obj.Spec.Template.Spec.Containers[0], m.Status.PublishingTo, tokenSecret)
 	}
 	return obj
@@ -92,6 +110,65 @@ func applyVersion(c *corev1.Container, version string) {
 	} else {
 		c.ImagePullPolicy = corev1.PullIfNotPresent
 	}
+}
+
+// applyProbes selects the container's health probes from the deployed MeshSync
+// version. Versions that serve the HTTP health endpoints (>= v1.0.1) get a
+// cheap httpGet /healthz liveness probe (no binary fork, so no false restarts
+// under the CPU pressure of the initial full-cluster sync) plus an httpGet
+// /readyz readiness probe that holds the pod NotReady until MeshSync has
+// connected to the broker once. Every other version - older images, moving
+// channel tags such as the default stable-latest, and unparseable tags - keeps
+// the exec liveness baked into the template and gets no readiness probe:
+// probing an image that serves nothing on the client port over HTTP would
+// connection-refuse and crashloop an otherwise-healthy pod (version skew,
+// since spec.version is user-settable).
+//
+// /readyz is a one-shot latch (it never flips back to 503 once connected), so
+// the readiness probe cannot wedge a running pod on a transient broker blip -
+// which is why it is safe here even though an earlier exec-based readiness
+// probe was removed for stalling rollout on CPU-starved nodes.
+func applyProbes(c *corev1.Container, version string) {
+	if !servesHealthEndpoints(version) {
+		// Keep the template's exec liveness; attach no readiness probe.
+		return
+	}
+	port := intstr.FromString(clientPortName)
+	c.LivenessProbe = &corev1.Probe{
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       30,
+		TimeoutSeconds:      5,
+		FailureThreshold:    5,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: healthzPath, Port: port},
+		},
+	}
+	c.ReadinessProbe = &corev1.Probe{
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      5,
+		FailureThreshold:    3,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: readyzPath, Port: port},
+		},
+	}
+}
+
+// servesHealthEndpoints reports whether spec.version is a pinned semantic
+// version at or above minHealthEndpointsVersion, i.e. an image known to serve
+// /healthz and /readyz. Moving channel tags (stable-latest, edge-latest, ""),
+// commit-sha tags, and versions predating the endpoints are unparseable or
+// lower and return false, so their pods stay on the exec liveness probe. The
+// gate is deliberately conservative: an unprovable version - including a
+// pre-release of the boundary version such as v1.0.1-rc.1, which sorts below
+// v1.0.1 and may predate the endpoint commit - is treated as lacking the
+// endpoints rather than risking an httpGet crashloop.
+func servesHealthEndpoints(version string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return !v.LessThan(minHealthEndpoints)
 }
 
 // setBrokerURL sets the BROKER_URL env var by name, leaving the template default

--- a/pkg/meshsync/meshsync_test.go
+++ b/pkg/meshsync/meshsync_test.go
@@ -20,15 +20,19 @@ import (
 	"testing"
 
 	mesheryv1alpha1 "github.com/meshery/meshery-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// testObjName is the name/namespace used for MeshSync CR fixtures in this file.
+const testObjName = "test"
+
 func TestGetObjects(t *testing.T) {
 	m := &mesheryv1alpha1.MeshSync{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
+			Name:      testObjName,
+			Namespace: testObjName,
 		},
 		Spec: mesheryv1alpha1.MeshSyncSpec{
 			Size: 1,
@@ -142,4 +146,108 @@ func TestWithTokenUserinfo(t *testing.T) {
 			t.Errorf("withTokenUserinfo(%q) = %q, want %q", in, got, want)
 		}
 	}
+}
+
+// TestServesHealthEndpoints locks in the version gate that decides whether a
+// MeshSync image is known to serve /healthz and /readyz. Only pinned semantic
+// versions at or above minHealthEndpointsVersion (v1.0.1) qualify; moving tags,
+// pre-releases of the boundary version, commit shas, and the empty default must
+// stay on the exec probe so an httpGet probe never crashloops an image that
+// serves nothing on the client port.
+func TestServesHealthEndpoints(t *testing.T) {
+	cases := map[string]bool{
+		"v1.0.1":        true,  // first release with the endpoints
+		"1.0.1":         true,  // the leading "v" is optional
+		"v1.0.2":        true,  // later patch
+		"v1.1.0":        true,  // later minor
+		"v2.0.0":        true,  // later major
+		"v1.1.0-beta.1": true,  // pre-release that still postdates v1.0.1
+		"v1.0.0":        false, // predates the endpoints
+		"v0.8.26":       false, // predates the endpoints
+		"v1.0.1-rc.1":   false, // pre-release of the boundary version, unprovable
+		"stable-latest": false, // moving channel tag, can't be proven
+		"edge-latest":   false, // moving channel tag, can't be proven
+		"latest":        false, // moving tag
+		"":              false, // empty -> template default image
+		"abc1234":       false, // commit-sha tag
+	}
+	for version, want := range cases {
+		if got := servesHealthEndpoints(version); got != want {
+			t.Errorf("servesHealthEndpoints(%q) = %v, want %v", version, got, want)
+		}
+	}
+}
+
+// TestGetServerObjectProbes verifies the built Deployment carries the right
+// probes for the deployed version: httpGet /healthz + /readyz for capable
+// versions, and the version-skew-safe exec liveness with no readiness probe for
+// everything else.
+func TestGetServerObjectProbes(t *testing.T) {
+	t.Run("capable version uses httpGet liveness and readiness", func(t *testing.T) {
+		c := builtMeshSyncContainer(t, "v1.0.1")
+		assertHTTPGetProbe(t, "liveness", c.LivenessProbe, healthzPath)
+		assertHTTPGetProbe(t, "readiness", c.ReadinessProbe, readyzPath)
+	})
+
+	// Moving tags, pre-endpoint pins, and the empty default must all fall back
+	// to the exec liveness probe with no readiness probe.
+	for _, version := range []string{"stable-latest", "v1.0.0", ""} {
+		version := version
+		t.Run("fallback keeps exec liveness and no readiness: "+versionLabel(version), func(t *testing.T) {
+			c := builtMeshSyncContainer(t, version)
+			if c.LivenessProbe == nil || c.LivenessProbe.Exec == nil {
+				t.Fatalf("expected the exec liveness probe, got %+v", c.LivenessProbe)
+			}
+			if c.LivenessProbe.HTTPGet != nil {
+				t.Error("fallback must not switch to an httpGet liveness probe")
+			}
+			if c.ReadinessProbe != nil {
+				t.Errorf("fallback must not attach a readiness probe, got %+v", c.ReadinessProbe)
+			}
+		})
+	}
+}
+
+// builtMeshSyncContainer builds the MeshSync Deployment for the given version
+// and returns its first (and only) container.
+func builtMeshSyncContainer(t *testing.T, version string) corev1.Container {
+	t.Helper()
+	m := &mesheryv1alpha1.MeshSync{
+		ObjectMeta: metav1.ObjectMeta{Name: testObjName, Namespace: testObjName},
+		Spec:       mesheryv1alpha1.MeshSyncSpec{Size: 1, Version: version},
+	}
+	dep, ok := GetServerObject(m, "").(*appsv1.Deployment)
+	if !ok {
+		t.Fatal("GetServerObject did not return a *appsv1.Deployment")
+	}
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal("built Deployment has no containers")
+	}
+	return dep.Spec.Template.Spec.Containers[0]
+}
+
+// assertHTTPGetProbe fails unless probe is an httpGet probe hitting path on the
+// named client port (and carries no exec handler).
+func assertHTTPGetProbe(t *testing.T, kind string, probe *corev1.Probe, path string) {
+	t.Helper()
+	if probe == nil || probe.HTTPGet == nil {
+		t.Fatalf("expected an httpGet %s probe, got %+v", kind, probe)
+	}
+	if probe.Exec != nil {
+		t.Errorf("%s probe must not retain an exec handler", kind)
+	}
+	if got := probe.HTTPGet.Path; got != path {
+		t.Errorf("%s path = %q, want %q", kind, got, path)
+	}
+	if got := probe.HTTPGet.Port.StrVal; got != clientPortName {
+		t.Errorf("%s probe must target the named %q port, got %q", kind, clientPortName, got)
+	}
+}
+
+// versionLabel renders the empty default version readably in subtest names.
+func versionLabel(v string) string {
+	if v == "" {
+		return "default"
+	}
+	return v
 }

--- a/pkg/meshsync/resources.go
+++ b/pkg/meshsync/resources.go
@@ -31,6 +31,11 @@ const (
 	meshsyncName    = "meshery-meshsync"
 	meshsyncService = "meshsync"
 
+	// clientPortName names the container port MeshSync listens on. It carries
+	// the broker client traffic and, as of v1.0.1, also serves the /healthz and
+	// /readyz HTTP health endpoints, so the httpGet probes target it by name.
+	clientPortName = "client"
+
 	// meshsyncImageRepo is the image repository spec.version tags resolve
 	// against.
 	meshsyncImageRepo = "meshery/meshsync"
@@ -99,7 +104,7 @@ var (
 							// No HostPort: pinning a host port would limit
 							// scheduling to one MeshSync per node for a port
 							// nothing external needs to reach.
-							Name:          "client",
+							Name:          clientPortName,
 							ContainerPort: val11000,
 						},
 					},
@@ -122,16 +127,24 @@ var (
 							corev1.ResourceMemory: MemoryLimit,
 						},
 					},
-					// MeshSync serves no HTTP health endpoint (its ping targets
-					// the broker's monitoring port), so the only probe available
-					// is exec'ing the binary — and `meshsync -h` only proves the
-					// binary can fork, nothing about sync health. During the
-					// initial full-cluster sync that fork can exceed any sane
-					// timeout on CPU-constrained nodes, marking a working pod
-					// unready forever. No Service routes to MeshSync, so a
-					// readiness probe gates nothing: it is intentionally absent.
-					// Liveness keeps a relaxed exec probe purely to restart a
-					// wedged container.
+					// Exec liveness is the version-skew-safe fallback baked into
+					// the template. As of v1.0.1 MeshSync serves HTTP /healthz
+					// (always 200) and /readyz (503 until it has connected to the
+					// broker once, then a permanent 200) on the client port, and
+					// applyProbes upgrades pods whose spec.version is a pinned
+					// semver >= that release to httpGet probes. Everything else
+					// keeps this exec probe: spec.version is user-settable and the
+					// default stable-latest (like every other moving tag) can't be
+					// proven to carry the endpoints, so an httpGet probe against an
+					// image that serves nothing on the client port would
+					// connection-refuse and crashloop an otherwise-healthy pod.
+					// `-h` only proves the binary can fork - nothing about sync
+					// health - and that fork can exceed a tight timeout during the
+					// initial full-cluster sync on CPU-starved nodes, so the probe
+					// stays deliberately relaxed. No readiness probe is attached
+					// for the same version-skew reason (and no Service routes to
+					// MeshSync, so readiness would gate no traffic); applyProbes
+					// adds one only for versions known to serve /readyz.
 					LivenessProbe: &corev1.Probe{
 						InitialDelaySeconds: 60,
 						PeriodSeconds:       30,


### PR DESCRIPTION
**Description**

This PR fixes #

Updates the MeshSync `Deployment` health probes to use the HTTP health endpoints that meshsync now serves, replacing a stale comment and an exec-only liveness probe.

**Symptom** – `pkg/meshsync/resources.go` claimed "MeshSync serves no HTTP health endpoint" and its liveness probe exec'd `./meshery-meshsync -h`.

**Root cause** – stale since meshsync **v1.0.1**, which added `GET /healthz` (liveness, always 200) and `GET /readyz` (readiness, 503 until the broker connects, then a permanent 200) on the client port (11000) - a port the operator already exposes.

**Fix - version-gated probes.** The probe strategy is gated on `spec.version` rather than switched unconditionally, because `spec.version` is user-settable and the operator can deploy older images (or moving tags like the default `stable-latest`) that predate the endpoints; an httpGet probe against those would connection-refuse and crashloop a healthy pod.

- `applyProbes` (`pkg/meshsync/meshsync.go`): a pinned semver **≥ v1.0.1** gets an httpGet `/healthz` liveness probe (cheap, no binary fork -> no false restarts under the CPU pressure of the initial full-cluster sync) **plus** an httpGet `/readyz` readiness probe that holds the pod NotReady until it has connected to the broker once.
- Moving channel tags (`stable-latest`, `edge-latest`), pinned versions **< v1.0.1**, the empty default, and unparseable tags keep the exec liveness with **no** readiness probe (version-skew-safe fallback).
- `/readyz` is a one-shot latch (never flips back to 503 once connected), so the readiness probe cannot wedge a running pod on a transient broker blip - unlike the earlier exec readiness probe that was deliberately removed for stalling rollout on CPU-starved nodes.
- Rewrote the stale comment, named the client container port via a constant reused by the probes, and documented the strategy in `docs/architecture.md`.

New unit coverage: the version gate (`TestServesHealthEndpoints`) and the built Deployment's probe shape for capable vs. fallback versions (`TestGetServerObjectProbes`). Adds `github.com/Masterminds/semver/v3` as a direct dependency (already in the tree, used for the gate).

**Out-of-scope fixes** (pre-existing `envtest` failures surfaced while running `make test`; confirmed on clean `master`, unrelated to the probe change, fixed rather than stepped over):

- `test(controllers)` - de-flaked the broker `CheckHealth` spec. The suite runs the real `BrokerReconciler`, which SSA-applies the `meshery-nats` StatefulSet on every reconcile of the `default` Broker CR; the spec deletes then plainly re-creates that StatefulSet, so the controller could recreate it in between and the test's `Create` intermittently hit a 409 `AlreadyExists`. Now adopts the existing object on `AlreadyExists` and drives readiness status via an `Eventually` that re-fetches first (so a concurrent reconcile bumping the `resourceVersion` cannot make the one-shot status update conflict).

> Rebased onto latest `master`. A third commit that fixed the same `TestGenerateToken` length assertion was dropped during the rebase because master already landed an equivalent fix (#837); the safety property remains covered by the existing Ginkgo no-digit-prefix test.

**Notes for Reviewers**

- **Default channel stays on exec.** `stable-latest` (the default) is a moving tag that can't be *proven* ≥ v1.0.1, so it keeps the exec liveness. Pods only upgrade to httpGet probes when `spec.version` is a pinned semver ≥ v1.0.1, or once the default is later pinned. This is intentional and conservative.
- **No CRD/RBAC/schema surface changes** - probes are pure resource-builder logic; `make manifests generate` produces no drift.
- Validated locally: `go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint` (0 issues), `go test ./pkg/...` (meshsync 85.7% coverage), and the controllers **specs** all pass.
- **`envtest` teardown (`controllers/suit_test.go`, `pkg/broker/suit_test.go`)** - the suites hard-exited via `os.Exit(1)` on any `testEnv.Stop()` error, masking the cause and turning a green suite red. The controllers manager ran under `ctrl.SetupSignalHandler()` (cancelled only by an OS signal), so `AfterSuite` stopped the control plane out from under a live manager. Fixed by driving the manager with a cancellable context and waiting for it to drain before `testEnv.Stop()`, replacing `os.Exit(1)` with Gomega assertions, and tolerating the known darwin `"timeout waiting for process"` control-plane stop artifact (logged, not fatal; every other Stop error still surfaces). `make test` now passes end to end locally, including the controllers and broker envtest suites.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

