### PR TITLE
Fix/kube rbac proxy image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder 
+FROM golang:1.26.4 as builder 
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml
+++ b/bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml
@@ -504,7 +504,7 @@ FnZVJlYWR5ccllPAAAAABJRU5ErkJggg=="
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: quay.io/brancz/kube-rbac-proxy:v0.16.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manifests/default.yaml
+++ b/config/manifests/default.yaml
@@ -402,7 +402,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/meshery-operator
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
This PR resolves the kube-rbac-proxy deployment failure caused by the deprecation and shutdown of the gcr.io/kubebuilder container registry. It updates the image reference to the active community-standard location hosted on quay.io.

Changes:
- Updated gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0 to quay.io/brancz/kube-rbac-proxy:v0.16.0 across:
  - config/default/manager_auth_proxy_patch.yaml
  - config/manifests/default.yaml
  - bundle/0.0.1/manifests/meshery-operator.clusterserviceversion.yaml

Verification:
- Tested and verified on a local Kubernetes cluster (OrbStack), confirming the operator transitions to 2/2 Running status and successfully pulls the container.
Before:
<img width="593" height="90" alt="Screenshot 2026-08-07 at 14 05 09" src="https://github.com/user-attachments/assets/73a41064-b179-462f-af1f-2cd5e8b77848" />

After: 

<img width="706" height="288" alt="            " src="https://github.com/user-attachments/assets/547e86ac-0f09-452f-b6c2-d8dcf3ee027b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the application runtime and build environment to Go 1.26.4.
  * Updated the Kubernetes authorization proxy image to version 0.16.0.
  * Improved compatibility and security for Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->